### PR TITLE
Avoid binding on public ip ports

### DIFF
--- a/dokku
+++ b/dokku
@@ -64,13 +64,20 @@ case "$1" in
 
     # start the app
     DOCKER_ARGS=$(: | pluginhook docker-args $APP)
-    id=$(docker run -d -p 5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
+    if [[ -f "$DOKKU_ROOT/VHOST" ]]; then
+      port=5000
+      id=$(docker run -d -e PORT=$port $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
+      ip=$(docker inspect $id |awk '/IPAddress/ {print $2}'|tr -d ',"')
+    else
+      id=$(docker run -d -p 5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
+      ip=127.0.0.1
+      port=$(docker port $id 5000 | sed 's/0.0.0.0://')
+    fi
     echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
-    port=$(docker port $id 5000 | sed 's/0.0.0.0://')
     echo $port > "$DOKKU_ROOT/$APP/PORT"
     echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
 
-    pluginhook post-deploy $APP $port
+    pluginhook post-deploy $APP $port $ip
     ;;
 
   cleanup)

--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-APP="$1"; PORT="$2"
+APP="$1"; PORT="$2"; IP="$3"
 WILDCARD_SSL="$DOKKU_ROOT/ssl"
 SSL="$DOKKU_ROOT/$APP/ssl"
 
@@ -22,7 +22,7 @@ if [[ -f "$DOKKU_ROOT/VHOST" ]]; then
   # ssl based nginx.conf
   if [[ -n "$SSL_INUSE" ]]; then
   cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf
-upstream $APP { server 127.0.0.1:$PORT; }
+upstream $APP { server $IP:$PORT; }
 server {
   listen      [::]:80;
   listen      80;
@@ -60,7 +60,7 @@ EOF
 else
 # default nginx.conf
   cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf
-upstream $APP { server 127.0.0.1:$PORT; }
+upstream $APP { server $IP:$PORT; }
 server {
   listen      [::]:80;
   listen      80;


### PR DESCRIPTION
I was thinking it would maybe be safer to avoid binding the docker images on public ports. Instead let nginx proxy to the private docker ip addresses. This way you avoid people portscanning your host and directly connecting to a running docker image, bypassing any security you might have put up in the nginx configuration.
