### PR TITLE
Issue #82: Hack on hack :)

### DIFF
--- a/dokku
+++ b/dokku
@@ -81,10 +81,18 @@ case "$1" in
 
   # temporary hack for https://github.com/progrium/dokku/issues/82
   deploy:all)
+    # Before stop all containers, in order to avoid port conflicts
+    for app in $(ls -d $HOME/*/); do
+       oldid=$(< "$app/CONTAINER")
+       docker kill $oldid > /dev/null
+    done
     for app in $(ls -d $HOME/*/); do
       APP=$(basename $app);
       IMAGE="app/$APP"
-      dokku deploy $APP $IMAGE
+      echo "-----> Re-deploying $APP..."
+      dokku deploy $APP $IMAGE > /dev/null
+      # Just to wait reload-nginx, otherwise socket closes...
+      sleep 1
     done
     ;;
 


### PR DESCRIPTION
There could be possible port conflicts between old dokku deploy and new dokku deploy (after reload) if a container of an app has taken a port already belonging to a different app. So it's better to stop all containers initially, and then proceed with all the deploys.
Finally, I found that calling too many dokku deploy one after the other causes the reload-nginx socket to be closed, so I wait 1s between deploys.
Hope this could be helpful before the final solution to issue #82.
