### PR TITLE
Move deploy script into a plugin

### DIFF
--- a/dokku
+++ b/dokku
@@ -46,21 +46,8 @@ case "$1" in
   deploy)
     APP="$2"; IMAGE="$3"
     pluginhook pre-deploy $APP $IMAGE
-
-    # kill the app when running
-    if [[ -f "$DOKKU_ROOT/$APP/PORT" ]]; then
-      oldid=$(< "$DOKKU_ROOT/$APP/CONTAINER")
-      docker kill $oldid > /dev/null
-    fi
-
-    # start the app
-    id=$(docker run -d -p 5000 -e PORT=5000 $IMAGE /bin/bash -c "/start web")
-    echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
-    port=$(docker port $id 5000 | sed 's/0.0.0.0://')
-    echo $port > "$DOKKU_ROOT/$APP/PORT"
-    echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
-
-    pluginhook post-deploy $APP $port
+    pluginhook run-deploy $APP $IMAGE
+    pluginhook post-deploy $APP $(< "$DOKKU_ROOT/$APP/PORT")
     ;;
 
   cleanup)

--- a/plugins/01_dokku-deploy/commands
+++ b/plugins/01_dokku-deploy/commands
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -eo pipefail
+cat

--- a/plugins/01_dokku-deploy/run-deploy
+++ b/plugins/01_dokku-deploy/run-deploy
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+APP="$1"
+IMAGE="$2"
+
+# kill the app when running
+if [[ -f "$DOKKU_ROOT/$APP/PORT" ]]; then
+  oldid=$(< "$DOKKU_ROOT/$APP/CONTAINER")
+  docker kill $oldid > /dev/null
+fi
+
+# start the app
+id=$(docker run -d -p 5000 -e PORT=5000 $IMAGE /bin/bash -c "/start web")
+echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
+port=$(docker port $id 5000 | sed 's/0.0.0.0://')
+echo $port > "$DOKKU_ROOT/$APP/PORT"
+echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -108,7 +108,6 @@ case "$1" in
     APP="$2"; APP_DIR="$DOKKU_ROOT/$APP"
     ENV_ADD=""
     ENV_TEMP=`cat "${ENV_FILE}"`
-    ID=$(< "$APP_DIR/CONTAINER")
     RESTART=false
     VARS="${*:3}"
 
@@ -151,7 +150,6 @@ case "$1" in
 
     APP="$2"; APP_DIR="$DOKKU_ROOT/$APP"
     ENV_TEMP=`cat "${ENV_FILE}"`
-    ID=$(< "$APP_DIR/CONTAINER")
     VARS="${*:3}"
 
     for var in $VARS; do


### PR DESCRIPTION
Hey. I've moved guts of the deploy command into a new plugin, ```01_dokku-deploy```. In doing this, it paves the way for other plugins to customise the deploy process a bit more. In my particular case, supporting the Shoreman plugin for greater process control:

https://github.com/musicglue/dokku-shoreman/blob/master/run-deploy
