### PR TITLE
Expose less ports from the host

### DIFF
--- a/dokku
+++ b/dokku
@@ -65,13 +65,15 @@ case "$1" in
 
     # start the app
     DOCKER_ARGS=$(: | pluginhook docker-args $APP)
-    id=$(docker run -d -p 5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
-    echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
-    port=$(docker port $id 5000 | sed 's/0.0.0.0://')
+    port=5000
     echo $port > "$DOKKU_ROOT/$APP/PORT"
+    id=$(docker run -d -e PORT=$port $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
+    echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
+    host=$(docker inspect $id | grep IPAddress | awk '{ print $2 }' | tr -d ',"')
+    echo $host > "$DOKKU_ROOT/$APP/IP"
     echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
 
-    pluginhook post-deploy $APP $port
+    pluginhook post-deploy $APP $port $host
     ;;
 
   cleanup)

--- a/dokku
+++ b/dokku
@@ -65,13 +65,27 @@ case "$1" in
 
     # start the app
     DOCKER_ARGS=$(: | pluginhook docker-args $APP)
-    port=5000
-    echo $port > "$DOKKU_ROOT/$APP/PORT"
-    id=$(docker run -d -e PORT=$port $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
+    if [[ -f "$DOKKU_ROOT/VHOST" ]]; then
+      port=5000
+      id=$(docker run -d -e PORT=$port $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
+      host=$(docker inspect $id | grep IPAddress | awk '{ print $2 }' | tr -d ',"')
+      vhost=$(< "$DOKKU_ROOT/VHOST")
+      subdomain=${APP/%\.${vhost}/}
+      if [[ "$APP" == *.* ]] && [[ "$subdomain" == "$APP" ]]; then
+        hostname="${APP/\//-}"
+      else
+        hostname="${APP/\//-}.$vhost"
+      fi
+      echo "http://$hostname" > "$DOKKU_ROOT/$APP/URL"
+    else
+      id=$(docker run -d -p 5000 -e PORT=$port $DOCKER_ARGS $IMAGE /bin/bash -c "/start web")
+      port=$(docker port $id 5000 | sed 's/0.0.0.0://')
+      host="127.0.0.1"
+      echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
+    fi
     echo $id > "$DOKKU_ROOT/$APP/CONTAINER"
-    host=$(docker inspect $id | grep IPAddress | awk '{ print $2 }' | tr -d ',"')
+    echo $port > "$DOKKU_ROOT/$APP/PORT"
     echo $host > "$DOKKU_ROOT/$APP/IP"
-    echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
 
     pluginhook post-deploy $APP $port $host
     ;;

--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-APP="$1"; PORT="$2"
+APP="$1"; PORT="$2"; IP="$3"
 WILDCARD_SSL="$DOKKU_ROOT/tls"
 SSL="$DOKKU_ROOT/$APP/tls"
 
@@ -28,7 +28,7 @@ EOF
   # ssl based nginx.conf
   if [[ -n "$SSL_INUSE" ]]; then
   cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf
-upstream $APP { server 127.0.0.1:$PORT; }
+upstream $APP { server $IP:$PORT; }
 server {
   listen      [::]:80;
   listen      80;
@@ -63,7 +63,7 @@ EOF
 else
 # default nginx.conf
   cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf
-upstream $APP { server 127.0.0.1:$PORT; }
+upstream $APP { server $IP:$PORT; }
 server {
   listen      [::]:80;
   listen      80;


### PR DESCRIPTION
Nginx running on the host is capable of forwarding directly into containers without needing port 5000 to be exposed from each one.

Say "SiteA" and "SiteB" are running in containers.  Currently, in master, port 5000 on both of them would be mapped to a port in the 49000-49900 range.  Let's say SiteA gets 49001 and SiteB gets 49002, for example.  Someone could connect to "http://sitea.example.com:49002/" to be connected to SiteB's container, and likewise "http://siteb.example.com:49001/" goes to SiteA.  In addition to being unwieldy, someone could enumerate every standard dokku container running on the machine by simply scanning the 49000-49900 range, which may or may not have security/architecture/whatever implications.

This PR changes this by configuring nginx to forward directly to the container's private 172.17.%.% address.  Unfortunately, it causes any of the nginx/vhost related plugins to break since they currently assume they can forward to "127.0.0.1:$PORT".  This is an easy fix; the changes made to the post-deploy hook of the default nginx-vhosts plugin in this PR can be used as an example.