### PR TITLE
Default DOKKU_ROOT to ~dokku if unspecified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ SSHCOMMAND_URL ?= https://raw.github.com/progrium/sshcommand/master/sshcommand
 PLUGINHOOK_URL ?= https://s3.amazonaws.com/progrium-pluginhook/pluginhook_0.1.0_amd64.deb
 STACK_URL ?= https://github.com/progrium/buildstep.git
 PREBUILT_STACK_URL ?= https://github.com/progrium/buildstep/releases/download/2014-03-08/2014-03-08_429d4a9deb.tar.gz
-DOKKU_ROOT ?= /home/dokku
 
 .PHONY: all install copyfiles version plugins dependencies sshcommand pluginhook docker aufs stack count
 
@@ -24,7 +23,7 @@ addman:
 	mandb
 
 version:
-	git describe --tags > ${DOKKU_ROOT}/VERSION  2> /dev/null || echo '~${DOKKU_VERSION} ($(shell date -uIminutes))' > ${DOKKU_ROOT}/VERSION
+	git describe --tags > ~dokku/VERSION  2> /dev/null || echo '~${DOKKU_VERSION} ($(shell date -uIminutes))' > ~dokku/VERSION
 
 plugins: pluginhook docker
 	dokku plugins-install

--- a/dokku
+++ b/dokku
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
-export DOKKU_ROOT=${DOKKU_ROOT:="/home/dokku"}
+export DOKKU_ROOT=${DOKKU_ROOT:=~dokku}
 export PLUGIN_PATH=${PLUGIN_PATH:="/var/lib/dokku/plugins"}
 
 [[ -f $DOKKU_ROOT/dokkurc ]] && source $DOKKU_ROOT/dokkurc


### PR DESCRIPTION
Our system puts user's home directory in a non-standard place.  Instead of being forced to set the DOKKU_ROOT to this new place, default to trying to get the dokku user's home directory via ~dokku.

Depends on this pull request in sshcommand: https://github.com/progrium/sshcommand/pull/10