### PR TITLE
expose the port for `dokku run $APP /bin/bash`

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -49,7 +49,7 @@ case "$1" in
     shift 2
 
     DOCKER_ARGS=$(: | pluginhook docker-args $APP)
-    docker run -i -t $DOCKER_ARGS $IMAGE /exec "$@"
+    docker run -i -t -p 5000 -e PORT=5000 $DOCKER_ARGS $IMAGE /exec "$@"
     ;;
 
   url | urls)


### PR DESCRIPTION
Super useful for debugging. So if you run `docker ps`:

```
CONTAINER ID        IMAGE                         COMMAND                CREATED             STATUS              PORTS                      NAMES
b55e977cbcd0        dokku/$APP:latest          "/exec /bin/bash"      6 seconds ago       Up 5 seconds        0.0.0.0:49176->5000/tcp    berserk_stallman
```