### PR TITLE
use forked ruby buildpack for multi test

### DIFF
--- a/tests.mk
+++ b/tests.mk
@@ -104,10 +104,7 @@ deploy-tests:
 	@$(QUIET) $(MAKE) deploy-test-gitsubmodules
 	@$(QUIET) $(MAKE) deploy-test-go
 	@$(QUIET) $(MAKE) deploy-test-java
-	# broken with new buildstep.
-	# ref: https://github.com/progrium/dokku/issues/832
-	# ref: https://github.com/heroku/heroku-buildpack-ruby/pull/319
-	# @$(QUIET) $(MAKE) deploy-test-multi
+	@$(QUIET) $(MAKE) deploy-test-multi
 	@$(QUIET) $(MAKE) deploy-test-nodejs-express
 	@$(QUIET) $(MAKE) deploy-test-php
 	@$(QUIET) $(MAKE) deploy-test-python-flask

--- a/tests/apps/multi/.buildpacks
+++ b/tests/apps/multi/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/heroku/heroku-buildpack-ruby
+https://github.com/michaelshobbs/heroku-buildpack-ruby
 https://github.com/heroku/heroku-buildpack-nodejs
 https://github.com/heroku/heroku-buildpack-python.git

--- a/tests/apps/multi/Gemfile
+++ b/tests/apps/multi/Gemfile
@@ -2,5 +2,5 @@ source "https://rubygems.org"
 
 ruby '1.9.3'
 
-gem 'compass'
+gem 'compass', ">= 1.0.1"
 gem 'sass-globbing'

--- a/tests/apps/multi/Gemfile.lock
+++ b/tests/apps/multi/Gemfile.lock
@@ -1,19 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    chunky_png (1.3.0)
-    compass (0.12.3)
+    chunky_png (1.3.3)
+    compass (1.0.1)
       chunky_png (~> 1.2)
-      fssm (>= 0.2.7)
-      sass (= 3.2.14)
-    fssm (0.2.10)
-    sass (3.2.14)
-    sass-globbing (1.1.0)
+      compass-core (~> 1.0.1)
+      compass-import-once (~> 1.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+      sass (>= 3.3.13, < 3.5)
+    compass-core (1.0.1)
+      multi_json (~> 1.0)
+      sass (>= 3.3.0, < 3.5)
+    compass-import-once (1.0.5)
+      sass (>= 3.2, < 3.5)
+    ffi (1.9.6)
+    multi_json (1.10.1)
+    rb-fsevent (0.9.4)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    sass (3.4.9)
+    sass-globbing (1.1.1)
       sass (>= 3.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  compass
+  compass (>= 1.0.1)
   sass-globbing


### PR DESCRIPTION
I'm not saying we necessarily merge this but if we want this test to be run before the heroku guys merge the `export` fix, then this will work.

 - uses my forked ruby buildpack that merges https://github.com/heroku/heroku-buildpack-ruby/pull/319
 - upgrades compass (1.0.1) to be compatible with grunt-contrib-compass

closes #832