### PR TITLE
Add missing properties to the php composer.json

### DIFF
--- a/tests/apps/php/composer.json
+++ b/tests/apps/php/composer.json
@@ -1,4 +1,6 @@
 {
+  "name": "test-php-app",
+  "description": "a test php app for dokku",
   "require": {
     "monolog/monolog": "~1.7",
     "silex/silex": "~1.1"


### PR DESCRIPTION
This avoids errors in deploying the test app. Composer recently updated to require this for all projects (which appears to be a bug).