### PR TITLE
give CACHE_PATH env variable for forward compatibility with herokuish

### DIFF
--- a/dokku
+++ b/dokku
@@ -54,7 +54,7 @@ case "$1" in
     docker commit $id $IMAGE > /dev/null
     [[ -d $CACHE_DIR ]] || mkdir $CACHE_DIR
     pluginhook pre-build $APP
-    id=$(docker run -d -v $CACHE_DIR:/cache $IMAGE /build/builder)
+    id=$(docker run -d -v $CACHE_DIR:/cache -e CACHE_PATH=/cache $IMAGE /build/builder)
     docker attach $id
     test "$(docker wait $id)" -eq 0
     docker commit $id $IMAGE > /dev/null


### PR DESCRIPTION
herokuish defaults to /tmp/cache, so the build cache don't work without giving the CACHE_PATH environment variable. You can test it with buildstep herokuish branch. cc @progrium