### PR TITLE
Pull new tags when upgrading to update VERSION

### DIFF
--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -8,7 +8,7 @@ To update the deploy step (this is updated less frequently):
 
 ```shell
 cd ~/dokku
-git pull origin master
+git pull --tags origin master
 sudo make install
 ```
 


### PR DESCRIPTION
During an upgrade, the output of `git describe --tags` is written to the VERSION file, so we need to pull the tags otherwise it looks like we're running an old version.