### PR TITLE
support both docker-args PHASE and docker-args-PHASE for the time being. closes #906

### DIFF
--- a/dokku
+++ b/dokku
@@ -55,7 +55,10 @@ case "$1" in
     [[ -d $CACHE_DIR ]] || mkdir $CACHE_DIR
     pluginhook pre-build $APP
 
+    # *DEPRECATED* in v0.4.0: `pluginhook docker-args` will be removed in future releases
+    # https://github.com/progrium/dokku/issues/896 & https://github.com/progrium/dokku/issues/906
     DOCKER_ARGS=$(: | pluginhook docker-args $APP build)
+    DOCKER_ARGS+=$(: | pluginhook docker-args-build $APP)
     id=$(docker run -d -v $CACHE_DIR:/cache -e CACHE_PATH=/cache $DOCKER_ARGS $IMAGE /build/builder)
     docker attach $id
     test "$(docker wait $id)" -eq 0
@@ -85,6 +88,7 @@ case "$1" in
 
     # start the app
     DOCKER_ARGS=$(: | pluginhook docker-args $APP deploy)
+    DOCKER_ARGS+=$(: | pluginhook docker-args-deploy $APP)
     BIND_EXTERNAL=$(pluginhook bind-external-ip $APP)
 
     if [[ "$BIND_EXTERNAL" = "false" ]];then

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -49,6 +49,7 @@ case "$1" in
     shift 2
 
     DOCKER_ARGS=$(: | pluginhook docker-args $APP run)
+    DOCKER_ARGS+=$(: | pluginhook docker-args-run $APP)
     [[ "$(/usr/bin/tty || true)" != "not a tty" ]] && DOKKU_RUN_OPTS="-i -t"
 
     docker run $DOKKU_RUN_OPTS $DOCKER_ARGS $IMAGE /exec "$@"


### PR DESCRIPTION
The idea here is to support docker-args more granularly by phase. See #896 and #906.