### PR TITLE
Skip building buildstep if SKIP_BUILD_STACK set. Useful for building dokku inside docker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,10 +96,14 @@ endif
 
 stack:
 	@echo "Start building buildstep"
+ifdef SKIP_BUILD_STACK
+	@echo "Skipping actual building"
+else
 ifdef BUILD_STACK
 	@docker images | grep progrium/buildstep || (git clone ${STACK_URL} /tmp/buildstep && docker build -t progrium/buildstep /tmp/buildstep && rm -rf /tmp/buildstep)
 else
 	@docker images | grep progrium/buildstep || curl --silent -L ${PREBUILT_STACK_URL} | gunzip -cd | docker import - progrium/buildstep
+endif
 endif
 
 count:


### PR DESCRIPTION
When building dokku inside docker itself, the 'stack' step fails because of unaccessible /var/run/docker.sock, which cannot be bound via Dockerfile.
Thus, the only option is to skip that step and instead pull 'progium/buildstep' directly from docker Hub.
Something like 'ENV SKIP_BUILD_STACK=YES' in Dockerfile is assumed.