### PR TITLE
enable ssl_prefer_server_ciphers

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -25,9 +25,7 @@ ssl_session_timeout 10m;
 
 ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
 ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
-# this is already defined in the base nginx.conf and causes nginx reloads/starts to fail
-# when its defined twice
-# ssl_prefer_server_ciphers on;
+ssl_prefer_server_ciphers on;
 
 # ssl_certificate $DOKKU_ROOT/tls/server.crt;
 # ssl_certificate_key $DOKKU_ROOT/tls/server.key;


### PR DESCRIPTION
Since we create /etc/nginx/nginx.conf we don't have "ssl_prefer_server_ciphers on" option enabled anymore, enable it in dokku.conf