### PR TITLE
first stab at a common functions library. include argument parsing and a few definitions wired up. closes #932. closes #945

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -35,11 +35,12 @@ The below plugin is a dummy `dokku hello` plugin. If your plugin exposes command
 ```shell
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$(dirname $0)/../common/functions"
 
 case "$1" in
   hello)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2";
 
     echo "Hello $APP"

--- a/dokku
+++ b/dokku
@@ -10,10 +10,18 @@ export PLUGIN_PATH=${PLUGIN_PATH:="/var/lib/dokku/plugins"}
 export DOKKU_NOT_IMPLEMENTED_EXIT=10
 export DOKKU_VALID_EXIT=0
 
+source "$PLUGIN_PATH/common/functions"
+
 [[ -f $DOKKU_ROOT/dokkurc ]] && source $DOKKU_ROOT/dokkurc
 [[ -d $DOKKU_ROOT/.dokkurc ]] && for f in $DOKKU_ROOT/.dokkurc/*; do source $f; done
 
 [[ $DOKKU_TRACE ]] && set -x
+
+parse_args "$@"
+for arg in "$@"; do
+  [[ "$arg" =~ ^-.* ]] && shift 1
+done
+! has_tty && DOKKU_QUIET_OUTPUT=1
 
 if [[ $(id -un) != "dokku" && $1 != plugins-install* && $1 != "plugins-update" ]]; then
   sudo -u dokku -E -H $0 "$@"
@@ -34,15 +42,15 @@ fi
 case "$1" in
   receive)
     APP="$2"; IMAGE="dokku/$APP"
-    echo "-----> Cleaning up ..."
+    info1 "Cleaning up ..."
     dokku cleanup
-    echo "-----> Building $APP ..."
+    info1 "Building $APP ..."
     cat | dokku build $APP
-    echo "-----> Releasing $APP ..."
+    info1 "Releasing $APP ..."
     dokku release $APP
-    echo "-----> Deploying $APP ..."
+    info1 "Deploying $APP ..."
     dokku deploy $APP
-    echo "=====> Application deployed:"
+    info2 "Application deployed:"
          dokku urls $APP | sed "s/^/       /"
     echo
     ;;
@@ -116,7 +124,7 @@ case "$1" in
 
     # run checks first, then post-deploy hooks, which switches Nginx traffic
     trap kill_new INT TERM EXIT
-    echo "-----> Running pre-flight checks"
+    info1 "Running pre-flight checks"
     pluginhook check-deploy $id $APP $port ${ipaddr:-localhost}
 
     # now using the new container
@@ -124,7 +132,7 @@ case "$1" in
     echo $port > "$DOKKU_ROOT/$APP/PORT"
     echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
 
-    echo "-----> Running post-deploy"
+    info1 "Running post-deploy"
     pluginhook post-deploy  $APP $port $ipaddr
     trap -        INT TERM EXIT
 
@@ -132,7 +140,7 @@ case "$1" in
     if [[ -n "$oldid" ]]; then
       # Let the old container finish processing requests, before terminating it
       WAIT="${DOKKU_WAIT_TO_RETIRE:-60}"
-      echo "-----> Shutting down old container in $WAIT seconds"
+      info1 "Shutting down old container in $WAIT seconds"
       (
         exec >/dev/null 2>/dev/null </dev/null
         trap '' INT HUP
@@ -176,7 +184,7 @@ case "$1" in
     ;;
 
   help|'')
-    echo "Usage: dokku COMMAND <app> [command-specific-options]"
+    echo "Usage: dokku [-q|--quiet|-t|--trace|--rm-container|-rm] COMMAND <app> [command-specific-options]"
     echo ""
     echo "Options:"
 
@@ -203,8 +211,8 @@ EOF
     done
 
     if [ "$implemented" -eq 0 ]; then
-      echo " !    \`$*\` is not a dokku command."
-      echo " !    See \`dokku help\` for a list of available commands."
+      warn "\`$*\` is not a dokku command."
+      warn "See \`dokku help\` for a list of available commands."
       exit 1
     fi
     ;;

--- a/dokku
+++ b/dokku
@@ -42,15 +42,15 @@ fi
 case "$1" in
   receive)
     APP="$2"; IMAGE="dokku/$APP"
-    info1 "Cleaning up ..."
+    dokku_log_info1 "Cleaning up ..."
     dokku cleanup
-    info1 "Building $APP ..."
+    dokku_log_info1 "Building $APP ..."
     cat | dokku build $APP
-    info1 "Releasing $APP ..."
+    dokku_log_info1 "Releasing $APP ..."
     dokku release $APP
-    info1 "Deploying $APP ..."
+    dokku_log_info1 "Deploying $APP ..."
     dokku deploy $APP
-    info2 "Application deployed:"
+    dokku_log_info2 "Application deployed:"
          dokku urls $APP | sed "s/^/       /"
     echo
     ;;
@@ -124,7 +124,7 @@ case "$1" in
 
     # run checks first, then post-deploy hooks, which switches Nginx traffic
     trap kill_new INT TERM EXIT
-    info1 "Running pre-flight checks"
+    dokku_log_info1 "Running pre-flight checks"
     pluginhook check-deploy $id $APP $port ${ipaddr:-localhost}
 
     # now using the new container
@@ -132,7 +132,7 @@ case "$1" in
     echo $port > "$DOKKU_ROOT/$APP/PORT"
     echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
 
-    info1 "Running post-deploy"
+    dokku_log_info1 "Running post-deploy"
     pluginhook post-deploy  $APP $port $ipaddr
     trap -        INT TERM EXIT
 
@@ -140,7 +140,7 @@ case "$1" in
     if [[ -n "$oldid" ]]; then
       # Let the old container finish processing requests, before terminating it
       WAIT="${DOKKU_WAIT_TO_RETIRE:-60}"
-      info1 "Shutting down old container in $WAIT seconds"
+      dokku_log_info1 "Shutting down old container in $WAIT seconds"
       (
         exec >/dev/null 2>/dev/null </dev/null
         trap '' INT HUP
@@ -211,8 +211,8 @@ EOF
     done
 
     if [ "$implemented" -eq 0 ]; then
-      warn "\`$*\` is not a dokku command."
-      warn "See \`dokku help\` for a list of available commands."
+      dokku_log_warn "\`$*\` is not a dokku command."
+      dokku_log_warn "See \`dokku help\` for a list of available commands."
       exit 1
     fi
     ;;

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$(dirname $0)/../common/functions"
 
 case "$1" in
   trace)
@@ -26,7 +27,7 @@ case "$1" in
 
   logs)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2";
 
     if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
@@ -43,21 +44,22 @@ case "$1" in
 
   run)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"; IMAGE="dokku/$APP"
 
     shift 2
 
     DOCKER_ARGS=$(: | pluginhook docker-args $APP run)
     DOCKER_ARGS+=$(: | pluginhook docker-args-run $APP)
-    [[ "$(/usr/bin/tty || true)" != "not a tty" ]] && DOKKU_RUN_OPTS="-i -t"
+    [[ $DOKKU_RM_CONTAINER ]] && DOKKU_RUN_OPTS="--rm"
+    has_tty && DOKKU_RUN_OPTS+=" -i -t"
 
     docker run $DOKKU_RUN_OPTS $DOCKER_ARGS $IMAGE /exec "$@"
     ;;
 
   url | urls)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"; SCHEME="http"; SSL="$DOKKU_ROOT/$APP/tls"; WILDCARD_SSL="$DOKKU_ROOT/tls"
 
     if [[ -e "$SSL/server.crt" && -e "$SSL/server.key" ]] || [[ -e "$WILDCARD_SSL/server.crt" && -e "$WILDCARD_SSL/server.key" ]]; then

--- a/plugins/apps/commands
+++ b/plugins/apps/commands
@@ -4,13 +4,13 @@ source "$(dirname $0)/../common/functions"
 
 case "$1" in
   apps)
-    info2 "My Apps"
+    dokku_log_info2_quiet "My Apps"
     find $DOKKU_ROOT -follow -maxdepth 1 -type d  \( ! -iname ".*" \)  -not -path $DOKKU_ROOT/tls | sed 's|^\./||g' | sed 's|'$DOKKU_ROOT'\/||' | tail -n +2 | sort
     ;;
 
   apps:create)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ -d "$DOKKU_ROOT/$2" ]] && warn "Name is already taken" && exit 1
+    [[ -d "$DOKKU_ROOT/$2" ]] && dokku_log_warn "Name is already taken" && exit 1
     APP="$2"
 
     mkdir -p "$DOKKU_ROOT/$APP"
@@ -25,14 +25,14 @@ case "$1" in
 
     [[ "$3" == "force" ]] && DOKKU_APPS_FORCE_DELETE=1
     if [[ -z "$DOKKU_APPS_FORCE_DELETE" ]]; then
-      warn "WARNING: Potentially Destructive Action"
-      warn "This command will destroy $APP (including all add-ons)."
-      warn "To proceed, type \"$APP\""
+      dokku_log_warn "WARNING: Potentially Destructive Action"
+      dokku_log_warn "This command will destroy $APP (including all add-ons)."
+      dokku_log_warn "To proceed, type \"$APP\""
       echo ""
 
       read -p "> " app_name
       if [[ "$app_name" != "$APP" ]]; then
-        warn "Confirmation did not match $APP. Aborted."
+        dokku_log_warn "Confirmation did not match $APP. Aborted."
         exit 1
       fi
     fi

--- a/plugins/apps/commands
+++ b/plugins/apps/commands
@@ -4,7 +4,7 @@ source "$(dirname $0)/../common/functions"
 
 case "$1" in
   apps)
-    [[ -z "$DOKKU_QUIET_OUTPUT" ]] && info2 "My Apps"
+    info2 "My Apps"
     find $DOKKU_ROOT -follow -maxdepth 1 -type d  \( ! -iname ".*" \)  -not -path $DOKKU_ROOT/tls | sed 's|^\./||g' | sed 's|'$DOKKU_ROOT'\/||' | tail -n +2 | sort
     ;;
 

--- a/plugins/apps/commands
+++ b/plugins/apps/commands
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$(dirname $0)/../common/functions"
 
 case "$1" in
   apps)
-    echo "=== My Apps"
+    [[ -z "$DOKKU_QUIET_OUTPUT" ]] && info2 "My Apps"
     find $DOKKU_ROOT -follow -maxdepth 1 -type d  \( ! -iname ".*" \)  -not -path $DOKKU_ROOT/tls | sed 's|^\./||g' | sed 's|'$DOKKU_ROOT'\/||' | tail -n +2 | sort
     ;;
 
   apps:create)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ -d "$DOKKU_ROOT/$2" ]] && echo " !    Name is already taken" && exit 1
+    [[ -d "$DOKKU_ROOT/$2" ]] && warn "Name is already taken" && exit 1
     APP="$2"
 
     mkdir -p "$DOKKU_ROOT/$APP"
@@ -18,19 +19,20 @@ case "$1" in
 
   apps:destroy)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     [[ "$2" == "tls" ]] && echo "Unable to destroy tls directory" && exit 1
-    APP="$2"; IMAGE="dokku/$APP"; FORCE="$3"
+    APP="$2"; IMAGE="dokku/$APP"
 
-    if [[ "$FORCE" != "force" ]]; then
-      echo " !    WARNING: Potentially Destructive Action"
-      echo " !    This command will destroy $APP (including all add-ons)."
-      echo " !    To proceed, type \"$APP\""
+    [[ "$3" == "force" ]] && DOKKU_APPS_FORCE_DELETE=1
+    if [[ -z "$DOKKU_APPS_FORCE_DELETE" ]]; then
+      warn "WARNING: Potentially Destructive Action"
+      warn "This command will destroy $APP (including all add-ons)."
+      warn "To proceed, type \"$APP\""
       echo ""
 
       read -p "> " app_name
       if [[ "$app_name" != "$APP" ]]; then
-        echo " !    Confirmation did not match $APP. Aborted."
+        warn "Confirmation did not match $APP. Aborted."
         exit 1
       fi
     fi

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -18,7 +18,7 @@ if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
 fi
 
 if [[ ! -z "$BUILD_ENV" ]]; then
-  info1 "Adding BUILD_ENV to build environment..."
+  dokku_log_info1 "Adding BUILD_ENV to build environment..."
   # create build env files for use in buildpacks like this:
   # https://github.com/niteoweb/heroku-buildpack-buildout/blob/5879fa3418f7d8e079f1aa5816ba1adde73f4948/bin/compile#L34
   id=$(echo $BUILD_ENV |sed 's@export @@g'| docker run -i -a stdin $IMAGE /bin/bash -c "for ENV_VAR in $(cat); do echo \$ENV_VAR |sed 's@^\([^=]*\)=\(.*\)\$@echo \\\"\2\\\" >/tmp/env/\1@g' >>/tmp/set_env.sh; done && mkdir -p /tmp/env && /bin/bash /tmp/set_env.sh")

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$(dirname $0)/../common/functions"
 
 APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
 
@@ -17,7 +18,7 @@ if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
 fi
 
 if [[ ! -z "$BUILD_ENV" ]]; then
-  echo "-----> Adding BUILD_ENV to build environment..."
+  info1 "Adding BUILD_ENV to build environment..."
   # create build env files for use in buildpacks like this:
   # https://github.com/niteoweb/heroku-buildpack-buildout/blob/5879fa3418f7d8e079f1aa5816ba1adde73f4948/bin/compile#L34
   id=$(echo $BUILD_ENV |sed 's@export @@g'| docker run -i -a stdin $IMAGE /bin/bash -c "for ENV_VAR in $(cat); do echo \$ENV_VAR |sed 's@^\([^=]*\)=\(.*\)\$@echo \\\"\2\\\" >/tmp/env/\1@g' >>/tmp/set_env.sh; done && mkdir -p /tmp/env && /bin/bash /tmp/set_env.sh")

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+function has_tty() {
+  if [[ "$(/usr/bin/tty || true)" == "not a tty" ]]; then
+    return 1
+  else
+    return 0
+  fi
+}
+
+function info1() {
+  echo "-----> $@"
+}
+
+function info2() {
+  echo "=====> $@"
+}
+
+function verbose() {
+  echo "       $@"
+}
+
+function warn() {
+  echo " !    $@"
+}
+
+function fail() {
+  echo "$@" 1>&2
+  exit 1
+}
+
+function verify_app_name() {
+  local APP="$1"
+  [[ ! -d "$DOKKU_ROOT/$APP" ]] && fail "App $APP does not exist"
+  return 0
+}
+
+function parse_args() {
+  for arg in "$@"; do
+    case "$arg" in
+      --quiet|-q)
+        export DOKKU_QUIET_OUTPUT=1
+        ;;
+      --trace|-t)
+        export DOKKU_TRACE=1
+        ;;
+      --rm-container|-rm)
+        export DOKKU_RM_CONTAINER=1
+        ;;
+      --force|-f)
+        export DOKKU_APPS_FORCE_DELETE=1
+        ;;
+    esac
+  done
+  return 0
+}

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -9,15 +9,15 @@ function has_tty() {
   fi
 }
 
-function info1() {
+function dokku_log_info1() {
   echo "-----> $@"
 }
 
-function info2() {
+function dokku_log_info2() {
   echo "=====> $@"
 }
 
-function info1_quiet() {
+function dokku_log_info1_quiet() {
   if [[ -z "$DOKKU_QUIET_OUTPUT" ]];then
     echo "-----> $@"
   else
@@ -25,7 +25,7 @@ function info1_quiet() {
   fi
 }
 
-function info2_quiet() {
+function dokku_log_info2_quiet() {
   if [[ -z "$DOKKU_QUIET_OUTPUT" ]];then
     echo "=====> $@"
   else
@@ -33,22 +33,22 @@ function info2_quiet() {
   fi
 }
 
-function verbose() {
+function dokku_log_verbose() {
   echo "       $@"
 }
 
-function warn() {
+function dokku_log_warn() {
   echo " !    $@"
 }
 
-function fail() {
+function dokku_log_fail() {
   echo "$@" 1>&2
   exit 1
 }
 
 function verify_app_name() {
   local APP="$1"
-  [[ ! -d "$DOKKU_ROOT/$APP" ]] && fail "App $APP does not exist"
+  [[ ! -d "$DOKKU_ROOT/$APP" ]] && dokku_log_fail "App $APP does not exist"
   return 0
 }
 

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -17,6 +17,22 @@ function info2() {
   echo "=====> $@"
 }
 
+function info1_quiet() {
+  if [[ -z "$DOKKU_QUIET_OUTPUT" ]];then
+    echo "-----> $@"
+  else
+    return 0
+  fi
+}
+
+function info2_quiet() {
+  if [[ -z "$DOKKU_QUIET_OUTPUT" ]];then
+    echo "=====> $@"
+  else
+    return 0
+  fi
+}
+
 function verbose() {
   echo "       $@"
 }

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -65,7 +65,7 @@ case "$1" in
       fi
     done
 
-    info2 "$APP config vars"
+    dokku_log_info2_quiet "$APP config vars"
     config_styled_hash "$VARS"
     ;;
 
@@ -131,7 +131,7 @@ ${var}"
     ENV_ADD=$(echo "$ENV_ADD" | tail -n +2) #remove first empty line
 
     if [ $RESTART_APP ]; then
-      info1 "Setting config vars and restarting $APP"
+      dokku_log_info1 "Setting config vars and restarting $APP"
       config_styled_hash "$ENV_ADD" "       "
 
       config_write "$ENV_TEMP"
@@ -154,7 +154,7 @@ ${var}"
     VARS="${*:3}"
 
     for var in $VARS; do
-      info1 "Unsetting $var and restarting $APP"
+      dokku_log_info1 "Unsetting $var and restarting $APP"
       ENV_TEMP=$(echo -e "${ENV_TEMP}" | sed "/^export $var=/ d")
 
       config_write "$ENV_TEMP"

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -65,7 +65,7 @@ case "$1" in
       fi
     done
 
-    [[ -z "$DOKKU_QUIET_OUTPUT" ]] && info2 "$APP config vars"
+    info2 "$APP config vars"
     config_styled_hash "$VARS"
     ;;
 

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$(dirname $0)/../common/functions"
 
 ENV_FILE="$DOKKU_ROOT/$2/ENV"
 ENV_FILE_TEMP="$DOKKU_ROOT/$2/ENV.tmp"
@@ -49,7 +50,7 @@ config_write() {
 case "$1" in
   config)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"
 
     config_create
@@ -64,13 +65,13 @@ case "$1" in
       fi
     done
 
-    echo "=== $APP config vars ==="
+    [[ -z "$DOKKU_QUIET_OUTPUT" ]] && info2 "$APP config vars"
     config_styled_hash "$VARS"
     ;;
 
   config:get)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"
 
     if [[ -z $3 ]]; then
@@ -91,7 +92,7 @@ case "$1" in
 
   config:set)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"
 
     if [[ -z "${*:3}" ]]; then
@@ -130,7 +131,7 @@ ${var}"
     ENV_ADD=$(echo "$ENV_ADD" | tail -n +2) #remove first empty line
 
     if [ $RESTART_APP ]; then
-      echo "-----> Setting config vars and restarting $APP"
+      info1 "Setting config vars and restarting $APP"
       config_styled_hash "$ENV_ADD" "       "
 
       config_write "$ENV_TEMP"
@@ -139,7 +140,7 @@ ${var}"
 
   config:unset)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"
 
     if [[ -z $3 ]]; then
@@ -153,7 +154,7 @@ ${var}"
     VARS="${*:3}"
 
     for var in $VARS; do
-      echo "-----> Unsetting $var and restarting $APP"
+      info1 "Unsetting $var and restarting $APP"
       ENV_TEMP=$(echo -e "${ENV_TEMP}" | sed "/^export $var=/ d")
 
       config_write "$ENV_TEMP"

--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -24,7 +24,7 @@ case "$1" in
     APP="$2"
 
     dokku domains:setup $APP
-    [[ -z "$DOKKU_QUIET_OUTPUT" ]] && info2 "$APP Domain Names"
+    info2 "$APP Domain Names"
     cat "$DOKKU_ROOT/$APP/VHOST"
     ;;
 

--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -24,7 +24,7 @@ case "$1" in
     APP="$2"
 
     dokku domains:setup $APP
-    info2 "$APP Domain Names"
+    dokku_log_info2_quiet "$APP Domain Names"
     cat "$DOKKU_ROOT/$APP/VHOST"
     ;;
 
@@ -44,7 +44,7 @@ case "$1" in
         [[ ! $(grep -q NO_VHOST "$DOKKU_ROOT/$APP/ENV") ]] && echo "export NO_VHOST='1'" >> "$DOKKU_ROOT/$APP/ENV"
       else
         if [[ -f "$DOKKU_ROOT/VHOST" ]]; then
-          info1 "Creating new $VHOST_PATH..."
+          dokku_log_info1 "Creating new $VHOST_PATH..."
           SUBDOMAIN=${APP/%\.${VHOST}/}
           hostname=$(: | pluginhook nginx-hostname $APP $SUBDOMAIN $VHOST)
           if [[ ! -n $hostname ]]; then
@@ -82,7 +82,7 @@ case "$1" in
     # we need to restart the app to make sure we're binding to the appropriate network interface
     dokku ps:restart $APP
     pluginhook post-domains-update $APP
-    info1 "Added $3 to $APP"
+    dokku_log_info1 "Added $3 to $APP"
 
     ;;
 
@@ -94,7 +94,7 @@ case "$1" in
     rm -f "$DOKKU_ROOT/$APP/VHOST"
     dokku domains:setup $APP
     pluginhook post-domains-update $APP
-    info1 "Cleared domains in $APP"
+    dokku_log_info1 "Cleared domains in $APP"
 
     ;;
 
@@ -112,7 +112,7 @@ case "$1" in
     dokku domains:setup $APP
     sed -i "/^$3$/d" "$DOKKU_ROOT/$APP/VHOST"
     pluginhook post-domains-update $APP
-    info1 "Removed $3 from $APP"
+    dokku_log_info1 "Removed $3 from $APP"
 
     ;;
 

--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$(dirname $0)/../common/functions"
 
 RE_IPV4="([0-9]{1,3}[\.]){3}[0-9]{1,3}"
 
@@ -19,17 +20,17 @@ RE_IPV6="${RE_IPV6}([0-9a-fA-F]{1,4}:){1,4}:${RE_IPV4}"                # TEST: 2
 case "$1" in
   domains)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"
 
     dokku domains:setup $APP
-    echo "=== $APP Domain Names"
+    [[ -z "$DOKKU_QUIET_OUTPUT" ]] && info2 "$APP Domain Names"
     cat "$DOKKU_ROOT/$APP/VHOST"
     ;;
 
   domains:setup)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"; VHOST_PATH="$DOKKU_ROOT/$APP/VHOST"
 
     if [[ ! -f $VHOST_PATH ]]; then
@@ -43,7 +44,7 @@ case "$1" in
         [[ ! $(grep -q NO_VHOST "$DOKKU_ROOT/$APP/ENV") ]] && echo "export NO_VHOST='1'" >> "$DOKKU_ROOT/$APP/ENV"
       else
         if [[ -f "$DOKKU_ROOT/VHOST" ]]; then
-          echo "-----> Creating new $VHOST_PATH..."
+          info1 "Creating new $VHOST_PATH..."
           SUBDOMAIN=${APP/%\.${VHOST}/}
           hostname=$(: | pluginhook nginx-hostname $APP $SUBDOMAIN $VHOST)
           if [[ ! -n $hostname ]]; then
@@ -62,7 +63,7 @@ case "$1" in
 
   domains:add)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"
 
     if [[ -z $3 ]]; then
@@ -81,25 +82,25 @@ case "$1" in
     # we need to restart the app to make sure we're binding to the appropriate network interface
     dokku ps:restart $APP
     pluginhook post-domains-update $APP
-    echo "-----> Added $3 to $APP"
+    info1 "Added $3 to $APP"
 
     ;;
 
   domains:clear)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"
 
     rm -f "$DOKKU_ROOT/$APP/VHOST"
     dokku domains:setup $APP
     pluginhook post-domains-update $APP
-    echo "-----> Cleared domains in $APP"
+    info1 "Cleared domains in $APP"
 
     ;;
 
   domains:remove)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"
 
     if [[ -z $3 ]]; then
@@ -111,7 +112,7 @@ case "$1" in
     dokku domains:setup $APP
     sed -i "/^$3$/d" "$DOKKU_ROOT/$APP/VHOST"
     pluginhook post-domains-update $APP
-    echo "-----> Removed $3 from $APP"
+    info1 "Removed $3 from $APP"
 
     ;;
 

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -63,7 +63,7 @@ EOF
         NONSSL_VHOSTS=$(egrep -v "^${SSL_HOSTNAME}$|^${SSL_HOSTNAME_ALT}$" $VHOST_PATH || exit 0)
 
         while read line; do
-          info1 "Configuring SSL for $line..."
+          dokku_log_info1 "Configuring SSL for $line..."
           SSL_SERVER_NAME=$line
           eval "cat <<< \"$(< $NGINX_CONF)\" >> $DOKKU_ROOT/$APP/nginx.conf"
         done <<< "$SSL_VHOSTS"
@@ -71,7 +71,7 @@ EOF
 
       APP_NGINX_TEMPLATE="$DOKKU_ROOT/$APP/nginx.conf.template"
       if [[ -f $APP_NGINX_TEMPLATE ]]; then
-        info1 "Overriding default nginx.conf with detected nginx.conf.template"
+        dokku_log_info1 "Overriding default nginx.conf with detected nginx.conf.template"
         NGINX_CONF=$APP_NGINX_TEMPLATE
       fi
 
@@ -80,11 +80,11 @@ EOF
       NOSSL_SERVER_NAME=$(echo $NONSSL_VHOSTS $SSL_VHOSTS| tr '\n' ' ')
 
       if [[ -n "$DOKKU_APP_LISTEN_PORT" ]] && [[ -n "$DOKKU_APP_LISTEN_IP" ]]; then
-        info1 "Creating $SCHEME nginx.conf"
+        dokku_log_info1 "Creating $SCHEME nginx.conf"
         echo "upstream $APP { server $DOKKU_APP_LISTEN_IP:$DOKKU_APP_LISTEN_PORT; }" > $DOKKU_ROOT/$APP/nginx.conf
         eval "cat <<< \"$(< $NGINX_CONF)\" >> $DOKKU_ROOT/$APP/nginx.conf"
 
-        info1 "Running nginx-pre-reload"
+        dokku_log_info1 "Running nginx-pre-reload"
         pluginhook nginx-pre-reload $APP $DOKKU_APP_LISTEN_PORT $DOKKU_APP_LISTEN_IP
 
         echo "       Reloading nginx"
@@ -92,14 +92,14 @@ EOF
       fi
     else
       if [[ -f "$DOKKU_ROOT/$APP/VHOST" ]]; then
-        info1 "VHOST support disabled, deleting $APP/VHOST"
+        dokku_log_info1 "VHOST support disabled, deleting $APP/VHOST"
         rm "$DOKKU_ROOT/$APP/VHOST"
       fi
       if [[ -f "$DOKKU_ROOT/$APP/nginx.conf" ]]; then
-        info1 "VHOST support disabled, deleting nginx.conf"
+        dokku_log_info1 "VHOST support disabled, deleting nginx.conf"
         rm "$DOKKU_ROOT/$APP/nginx.conf"
 
-        info1 "VHOST support disabled, reloading nginx after nginx.conf deletion"
+        dokku_log_info1 "VHOST support disabled, reloading nginx after nginx.conf deletion"
         restart_nginx
       fi
     fi

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$(dirname $0)/../common/functions"
 
 restart_nginx () {
   case "$DOKKU_DISTRO" in
@@ -62,7 +63,7 @@ EOF
         NONSSL_VHOSTS=$(egrep -v "^${SSL_HOSTNAME}$|^${SSL_HOSTNAME_ALT}$" $VHOST_PATH || exit 0)
 
         while read line; do
-          echo "-----> Configuring SSL for $line..."
+          info1 "Configuring SSL for $line..."
           SSL_SERVER_NAME=$line
           eval "cat <<< \"$(< $NGINX_CONF)\" >> $DOKKU_ROOT/$APP/nginx.conf"
         done <<< "$SSL_VHOSTS"
@@ -70,7 +71,7 @@ EOF
 
       APP_NGINX_TEMPLATE="$DOKKU_ROOT/$APP/nginx.conf.template"
       if [[ -f $APP_NGINX_TEMPLATE ]]; then
-        echo "-----> Overriding default nginx.conf with detected nginx.conf.template"
+        info1 "Overriding default nginx.conf with detected nginx.conf.template"
         NGINX_CONF=$APP_NGINX_TEMPLATE
       fi
 
@@ -79,11 +80,11 @@ EOF
       NOSSL_SERVER_NAME=$(echo $NONSSL_VHOSTS $SSL_VHOSTS| tr '\n' ' ')
 
       if [[ -n "$DOKKU_APP_LISTEN_PORT" ]] && [[ -n "$DOKKU_APP_LISTEN_IP" ]]; then
-        echo "-----> Creating $SCHEME nginx.conf"
+        info1 "Creating $SCHEME nginx.conf"
         echo "upstream $APP { server $DOKKU_APP_LISTEN_IP:$DOKKU_APP_LISTEN_PORT; }" > $DOKKU_ROOT/$APP/nginx.conf
         eval "cat <<< \"$(< $NGINX_CONF)\" >> $DOKKU_ROOT/$APP/nginx.conf"
 
-        echo "-----> Running nginx-pre-reload"
+        info1 "Running nginx-pre-reload"
         pluginhook nginx-pre-reload $APP $DOKKU_APP_LISTEN_PORT $DOKKU_APP_LISTEN_IP
 
         echo "       Reloading nginx"
@@ -91,14 +92,14 @@ EOF
       fi
     else
       if [[ -f "$DOKKU_ROOT/$APP/VHOST" ]]; then
-        echo "-----> VHOST support disabled, deleting $APP/VHOST"
+        info1 "VHOST support disabled, deleting $APP/VHOST"
         rm "$DOKKU_ROOT/$APP/VHOST"
       fi
       if [[ -f "$DOKKU_ROOT/$APP/nginx.conf" ]]; then
-        echo "-----> VHOST support disabled, deleting nginx.conf"
+        info1 "VHOST support disabled, deleting nginx.conf"
         rm "$DOKKU_ROOT/$APP/nginx.conf"
 
-        echo "-----> VHOST support disabled, reloading nginx after nginx.conf deletion"
+        info1 "VHOST support disabled, reloading nginx after nginx.conf deletion"
         restart_nginx
       fi
     fi
@@ -106,7 +107,7 @@ EOF
 
   nginx:import-ssl)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     [[ -t 0 ]] && echo "Tar archive containing server.crt and server.key expected on stdin" && exit 1
     APP="$2"
 

--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -7,7 +7,7 @@ APP="$1"; PORT="$2"; IP="$3"
 set +e; NO_VHOST=$(dokku config:get $APP NO_VHOST); set -e
 
 if [[ -n "$NO_VHOST" ]]; then
-  info1 "NO_VHOST config detected"
+  dokku_log_info1 "NO_VHOST config detected"
 elif [[ ! -f "$DOKKU_ROOT/$APP/VHOST" ]]; then
   dokku domains:setup $APP
 fi

--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$(dirname $0)/../common/functions"
 
 APP="$1"; PORT="$2"; IP="$3"
 
 set +e; NO_VHOST=$(dokku config:get $APP NO_VHOST); set -e
 
 if [[ -n "$NO_VHOST" ]]; then
-  echo "-----> NO_VHOST config detected"
+  info1 "NO_VHOST config detected"
 elif [[ ! -f "$DOKKU_ROOT/$APP/VHOST" ]]; then
   dokku domains:setup $APP
 fi

--- a/plugins/nginx-vhosts/post-domains-update
+++ b/plugins/nginx-vhosts/post-domains-update
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$(dirname $0)/../common/functions"
 
 APP="$1"
 

--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$(dirname $0)/../common/functions"
 
 release_and_deploy() {
+  source "$(dirname $0)/../common/functions"
   local APP="$1";
 
   if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
-    echo "-----> Releasing $APP ..."
+    info1 "Releasing $APP ..."
     dokku release $APP
-    echo "-----> Release complete!"
-    echo "-----> Deploying $APP ..."
+    info1 "Release complete!"
+    info1 "Deploying $APP ..."
     dokku deploy $APP
-    echo "=====> Application deployed:"
+    info2 "Application deployed:"
          dokku urls $APP | sed "s/^/       /"
     echo
   fi
@@ -19,7 +21,7 @@ release_and_deploy() {
 case "$1" in
   ps)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
 
     APP="$2"; [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]] && CONTAINER_ID=$(< "$DOKKU_ROOT/$APP/CONTAINER")
     [[ -z "$CONTAINER_ID" ]] && echo "App $APP has not been deployed" && exit 0
@@ -29,7 +31,7 @@ case "$1" in
 
   ps:start)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
 
     APP="$2"; [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]] && CONTAINER_ID=$(< "$DOKKU_ROOT/$APP/CONTAINER")
     [[ -z "$CONTAINER_ID" ]] && echo "App $APP has not been deployed" && exit 0
@@ -43,7 +45,7 @@ case "$1" in
 
   ps:stop)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
 
     APP="$2"; [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]] && CONTAINER_ID=$(< "$DOKKU_ROOT/$APP/CONTAINER")
     [[ -z "$CONTAINER_ID" ]] && echo "App $APP has not been deployed" && exit 0
@@ -58,7 +60,7 @@ case "$1" in
 
   ps:rebuild)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
     APP="$2"
 
     dokku git-build $APP
@@ -74,7 +76,7 @@ case "$1" in
 
   ps:restart)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    [[ ! -d "$DOKKU_ROOT/$2" ]] && echo "App $2 does not exist" && exit 1
+    verify_app_name "$2"
 
     APP="$2"; [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]] && CONTAINER_ID=$(< "$DOKKU_ROOT/$APP/CONTAINER")
     [[ -z "$CONTAINER_ID" ]] && echo "App $APP has not been deployed" && exit 0

--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -7,12 +7,12 @@ release_and_deploy() {
   local APP="$1";
 
   if [[ -f "$DOKKU_ROOT/$APP/CONTAINER" ]]; then
-    info1 "Releasing $APP ..."
+    dokku_log_info1 "Releasing $APP ..."
     dokku release $APP
-    info1 "Release complete!"
-    info1 "Deploying $APP ..."
+    dokku_log_info1 "Release complete!"
+    dokku_log_info1 "Deploying $APP ..."
     dokku deploy $APP
-    info2 "Application deployed:"
+    dokku_log_info2 "Application deployed:"
          dokku urls $APP | sed "s/^/       /"
     echo
   fi

--- a/tests/unit/client.bats
+++ b/tests/unit/client.bats
@@ -21,7 +21,7 @@ teardown() {
 }
 
 @test "dokku client (no args should print help)" {
-  run /bin/bash -c "./contrib/dokku_client.sh | head -1 | grep -q 'dokku COMMAND <app>'"
+  run /bin/bash -c "./contrib/dokku_client.sh | head -1 | egrep -q '^Usage: dokku \[.+\] COMMAND <app>.*'"
   echo "output: "$output
   echo "status: "$status
   assert_success


### PR DESCRIPTION
To be clear, this is a *first* pass. Please have a look and beat it up.

Includes options to enable tracing, auto rm containers on `run`, and "quiet" output. The command line args just set env variables and thus can be used for multiple plugins/commands simultaneously.

This also sets DOKKU_QUIET_OUTPUT if we do not have a tty.