### PR TITLE
Add apparmor and cgroup-lite as pre-dependencies for dokku debian package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: base
 Priority: optional
 Architecture: amd64
 Depends: locales, git, make, curl, software-properties-common, lxc-docker (>= 1.4.0), gcc, python-software-properties, man-db, buildstep, sshcommand, pluginhook
-Pre-Depends: nginx, dnsutils, ruby, ruby-dev, rubygem-rack, rubygem-rack-protection, rubygem-sinatra, rubygem-tilt
+Pre-Depends: nginx, dnsutils, ruby, ruby-dev, rubygem-rack, rubygem-rack-protection, rubygem-sinatra, rubygem-tilt, apparmor, cgroup-lite
 Provides: dokku
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 Description: Docker powered mini-Heroku in around 100 lines of Bash


### PR DESCRIPTION
Certain operating systems do not have these packages by default and they are required by lxc-docker