### PR TITLE
Switch to yabawock's static nginx buildpack

### DIFF
--- a/tests/apps/static/.env
+++ b/tests/apps/static/.env
@@ -1,1 +1,1 @@
-export BUILDPACK_URL=https://github.com/florianheinemann/buildpack-nginx
+export BUILDPACK_URL=https://github.com/yabawock/buildpack-nginx


### PR DESCRIPTION
The new herokuish branch of buildstep requires changes to the buildpack, but this buildpack should be compatible with the old buildstep.