### PR TITLE
Improve Dockerfile example/test

### DIFF
--- a/tests/apps/dockerfile/Dockerfile
+++ b/tests/apps/dockerfile/Dockerfile
@@ -4,8 +4,11 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 EXPOSE 5000
 
-ADD . /app
 RUN apt-get install -y software-properties-common && add-apt-repository ppa:chris-lea/node.js && apt-get update
 RUN apt-get install -y build-essential curl postgresql-client-9.3 nodejs git
-RUN cd /app && npm install
-CMD cd /app && npm start
+
+COPY . /app
+WORKDIR /app
+RUN npm install
+
+CMD npm start


### PR DESCRIPTION
Placing `COPY` (or `ADD`) of the application directory after the `RUN apt-get install ...` statements will allow the layers created from those statements to be retrieved from docker's cache on subsequent runs.