### PR TITLE
remove quoting around cleanup and disable lint for those lines. also make cleanup test more robust

### DIFF
--- a/dokku
+++ b/dokku
@@ -122,9 +122,11 @@ case "$1" in
 
   cleanup)
     # delete all non-running container
-    docker rm "$(docker ps -a -f 'status=exited' -q)" &> /dev/null &
+    # shellcheck disable=SC2046
+    docker rm $(docker ps -a -f 'status=exited' -q) &> /dev/null &
     # delete unused images
-    docker rmi "$(docker images -f 'dangling=true' -q)" &> /dev/null &
+    # shellcheck disable=SC2046
+    docker rmi $(docker images -f 'dangling=true' -q) &> /dev/null &
     ;;
 
   plugins)

--- a/tests/unit/cleanup.bats
+++ b/tests/unit/cleanup.bats
@@ -11,12 +11,12 @@ teardown() {
 }
 
 @test "remove exited containers" {
-  run dokku run $TEST_APP hostname
+  # make sure we have many exited containers of the same 'type'
+  run bash -c "for cnt in 1 2 3; do dokku run $TEST_APP hostname; done"
   echo "output: "$output
   echo "status: "$status
-  container="$output"
   assert_success
-  run bash -c "docker ps -a -f 'status=exited' -q --no-trunc=false | grep -q $container"
+  run bash -c "docker ps -a -f 'status=exited' --no-trunc=false | grep '/exec hostname'"
   echo "output: "$output
   echo "status: "$status
   assert_success
@@ -24,7 +24,8 @@ teardown() {
   echo "output: "$output
   echo "status: "$status
   assert_success
-  run bash -c "docker ps -a -f 'status=exited' -q --no-trunc=false | grep -q $container"
+  sleep 5  # wait for dokku cleanup to happen in the background
+  run bash -c "docker ps -a -f 'status=exited' --no-trunc=false | grep '/exec hostname'"
   echo "output: "$output
   echo "status: "$status
   assert_failure


### PR DESCRIPTION
the quoting 'required' by shellcheck (#SC2046) breaks `dokku cleanup`. this removes the quoting and disables the linting for that rule on these lines. 

also our tests were naive and only looked to see that latest container was removed. that's fixed here.