### PR TITLE
remove quoting from dockerfile env. closes #1002

### DIFF
--- a/plugins/config/docker-args-deploy
+++ b/plugins/config/docker-args-deploy
@@ -7,8 +7,8 @@ DOCKERFILE_ENV_FILE="$DOKKU_ROOT/$APP/DOCKERFILE_ENV_FILE"
 
 if ! is_image_buildstep_based "$IMAGE"; then
   > "$DOCKERFILE_ENV_FILE"
-  [[ -f "$DOKKU_ROOT/ENV" ]] && sed -e "s:^export ::g" "$DOKKU_ROOT/ENV" > "$DOCKERFILE_ENV_FILE"
-  [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && sed -e "s:^export ::g" "$DOKKU_ROOT/$APP/ENV" >> "$DOCKERFILE_ENV_FILE"
+  [[ -f "$DOKKU_ROOT/ENV" ]] && sed -e "s:^export ::g" -e "s:=':=:g" -e "s:'$::g" "$DOKKU_ROOT/ENV" > "$DOCKERFILE_ENV_FILE"
+  [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && sed -e "s:^export ::g" -e "s:=':=:g" -e "s:'$::g" "$DOKKU_ROOT/$APP/ENV" >> "$DOCKERFILE_ENV_FILE"
 
   echo "$STDIN --env-file=$DOCKERFILE_ENV_FILE"
 else

--- a/plugins/config/docker-args-run
+++ b/plugins/config/docker-args-run
@@ -1,0 +1,1 @@
+docker-args-deploy

--- a/tests/unit/config.bats
+++ b/tests/unit/config.bats
@@ -59,7 +59,7 @@ teardown() {
 
 @test "global config (dockerfile)" {
   deploy_app dockerfile
-  run bash -c "docker inspect --format '{{ .Config.Env }}' $(< $DOKKU_ROOT/$TEST_APP/CONTAINER) | grep global_test"
+  run bash -c "dokku run $TEST_APP env | egrep '^global_test=true'"
   echo "output: "$output
   echo "status: "$status
   assert_success


### PR DESCRIPTION
- removes single quotes from the generated `DOCKERFILE_ENV_FILE`
  - these are not needed by dockerfile deployments but are by buildpack deployments
- adds link to config/docker-args-run
- makes dockerfile test the same as buildpack test