### PR TITLE
Support xip.io wildcard DNS as a VHOST

### DIFF
--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -17,6 +17,11 @@ RE_IPV6="${RE_IPV6}fe08:(:[0-9a-fA-F]{1,4}){2,2}%[0-9a-zA-Z]{1,}|"     # TEST: f
 RE_IPV6="${RE_IPV6}::(ffff(:0{1,4}){0,1}:){0,1}${RE_IPV4}|"            # TEST: ::255.255.255.255   ::ffff:255.255.255.255  ::ffff:0:255.255.255.255 (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
 RE_IPV6="${RE_IPV6}([0-9a-fA-F]{1,4}:){1,4}:${RE_IPV4}"                # TEST: 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33
 
+# Ensure the ip address continues to the end of the line
+# Fixes using a wildcard dns service such as xip.io which allows for *.<ip address>.xip.io
+RE_IPV4="${RE_IPV4}\$"
+RE_IPV6="${RE_IPV6}\$"
+
 case "$1" in
   domains)
     [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1


### PR DESCRIPTION
http://xip.io

xip.io is a service by Basecamp that provides a wildcard DNS service on the public internet. Any \<ip address>.xip.io will return a DNS response for the IP address, same with \<subdomain>.\<ip address>.xip.io.

The domains plugin in dokku uses a regex to match IP4 and IP6 addresses in the VHOST file, and disables VHOST support if found. This PR changes those patterns to require that the VHOST entry **ends with** the IP address.

This is a gist where my VHOST setting is "127.0.0.1.xip.io" that demonstrates the original output, linked directly to the line from `plugins/domains/commands`: https://gist.github.com/anonymous/c529177f20b36beda80d#file-debug-log-L1373