### PR TITLE
[client unit-test] don't run create/destroy twice. actually clean up from create

### DIFF
--- a/tests/unit/client.bats
+++ b/tests/unit/client.bats
@@ -27,20 +27,16 @@ teardown() {
   assert_success
 }
 
-@test "dokku client (apps:create)" {
-  destroy_app
-  run ./contrib/dokku_client.sh apps:create $TEST_APP
+@test "dokku client (apps:create AND apps:destroy)" {
+  setup_client_repo
+  run bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh apps:create"
   echo "output: "$output
   echo "status: "$status
   assert_success
-}
-
-@test "dokku client (apps:destroy)" {
-  run ./contrib/dokku_client.sh -- --force apps:destroy $TEST_APP
+  run bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh --force apps:destroy"
   echo "output: "$output
   echo "status: "$status
   assert_success
-  create_app # prevent teardown() failure
 }
 
 @test "dokku client (config:set)" {
@@ -160,18 +156,6 @@ teardown() {
   echo "status: "$status
   assert_success
   run bash -c "docker ps -q --no-trunc | grep -q $(< $DOKKU_ROOT/$TEST_APP/CONTAINER)"
-  echo "output: "$output
-  echo "status: "$status
-  assert_success
-}
-
-@test "dokku client (apps:create AND apps:destroy)" {
-  setup_client_repo
-  run bash -c "${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh apps:create"
-  echo "output: "$output
-  echo "status: "$status
-  assert_success
-  run bash -c "echo ${BATS_TEST_DIRNAME}/../../contrib/dokku_client.sh --force apps:destroy"
   echo "output: "$output
   echo "status: "$status
   assert_success


### PR DESCRIPTION
we were running `apps:create` and `apps:destroy` twice in the client unit tests and weren't cleaning up after the second time. i think this was a botched when we dropped `create` and `destroy`