### PR TITLE
Added container ID to post-deploy as last arg.

### DIFF
--- a/dokku
+++ b/dokku
@@ -99,7 +99,7 @@ case "$1" in
     echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$port" > "$DOKKU_ROOT/$APP/URL"
 
     dokku_log_info1 "Running post-deploy"
-    pluginhook post-deploy  $APP $port $ipaddr
+    pluginhook post-deploy  $APP $port $ipaddr $id
     trap -        INT TERM EXIT
 
     # kill the old container


### PR DESCRIPTION
I needed container ID for my post-deploy hook so here is a pull that adds $id as the last arg (so as not to mess anyones current apps up) to post-deploy.

Thoughts?