### PR TITLE
confine arg shifting to between dokku and command. closes #1017

### DIFF
--- a/dokku
+++ b/dokku
@@ -18,9 +18,16 @@ source "$PLUGIN_PATH/common/functions"
 [[ $DOKKU_TRACE ]] && set -x
 
 parse_args "$@"
-for arg in "$@"; do
-  [[ "$arg" =~ ^--.* ]] && shift 1
-done
+args=("$@")
+if [[ "${args[0]}" =~ ^--.* ]]; then
+  for arg in "$@"; do
+    if [[ "$arg" =~ ^--.* ]];then
+      shift 1
+    else
+      break
+    fi
+  done
+fi
 ! has_tty && DOKKU_QUIET_OUTPUT=1
 
 if [[ $(id -un) != "dokku" && $1 != plugins-install* && $1 != "plugins-update" ]]; then

--- a/tests/unit/00_dokku-standard.bats
+++ b/tests/unit/00_dokku-standard.bats
@@ -28,6 +28,14 @@ teardown() {
   assert_success
 }
 
+@test "run (with --options)" {
+  deploy_app
+  run /bin/bash -c "dokku --force --quiet run $TEST_APP node --version"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+}
+
 @test "urls (non-ssl)" {
   run bash -c "dokku urls $TEST_APP | grep dokku.me"
   echo "output: "$output


### PR DESCRIPTION
This effectively enforces dokku "global" options position to exist between `dokku` and `command`