### PR TITLE
Change Slack Notifications link

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -77,7 +77,7 @@ Note: The following plugins have been supplied by our community and may not have
 [Zenedith]: https://github.com/Zenedith
 [sekjun9878]: https://github.com/sekjun9878
 [Flink]: https://github.com/Flink
-[ebeigarts]: https://github.com/ebeigarts
+[ribot]: https://github.com/ribot
 
 ### Datastores
 
@@ -191,7 +191,7 @@ Note: The following plugins have been supplied by our community and may not have
 | [Bower/Grunt](https://github.com/thrashr888/dokku-bower-grunt-build-plugin)                       | [thrashr888][]        |                       |
 | [Bower/Gulp](https://github.com/gdi2290/dokku-bower-gulp-build-plugin)                            | [gdi2290][]           |                       |
 | [HipChat Notifications](https://github.com/cef/dokku-hipchat)                                     | [cef][]               |                       |
-| [Slack Notifications](https://github.com/ebeigarts/dokku-slack)                                   | [ebeigarts][]         |                       |
+| [Slack Notifications](https://github.com/ribot/dokku-slack)                                       | [ribot][]             |                       |
 | [Graphite/statsd](https://github.com/jlachowski/dokku-graphite-plugin)                            | [jlachowski][]        |                       |
 | [APT](https://github.com/F4-Group/dokku-apt)                                                      | [F4-Group][]          |                       |
 | [User ACL](https://github.com/mlebkowski/dokku-acl)                                               | [Maciej Łebkowski][]  |                       |


### PR DESCRIPTION
My changes to `dokku-slack` have been merged upstream (ribot), so let's point to that.