### PR TITLE
Extract nginx.conf from application

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -47,9 +47,9 @@ This archive should is expanded via `tar xvf`. It should contain `server.crt` an
 
 > New as of 0.3.10
 
-Dokku currently templates out an nginx configuration that is included in the `nginx-vhosts` plugin. If you'd like to provide a custom template for your application, you should copy the existing template - ssl or non-ssl - into your `$DOKKU_ROOT/$APP` directory at the file `nginx.conf.template`.
+Dokku currently templates out an nginx configuration that is included in the `nginx-vhosts` plugin. If you'd like to provide a custom template for your application, copy the existing template - ssl or non-ssl - into your application's root directory as the file `nginx.conf`. The next time you deploy, Nginx will use your template instead of the default.
 
-For instance - assuming defaults - to customize the nginx template in use for the `myapp` application, create a file at `/home/dokku/myapp/nginx.conf.template` with the following contents:
+For instance - assuming defaults - to customize the nginx template in use, create the file `nginx.conf` with the following contents:
 
 ```
 server {
@@ -75,7 +75,7 @@ server {
 }
 ```
 
-The above is a sample, http configuration that adds an `X-Served-By` header to requests. The template is manually uploaded this template file and **must** it owned by `dokku:dokku`.
+The above is a sample, http configuration that adds an `X-Served-By` header to requests.
 
 ## Customizing hostnames
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -45,7 +45,7 @@ This archive should is expanded via `tar xvf`. It should contain `server.crt` an
 
 ## Customizing the nginx configuration
 
-> New as of 0.3.10
+> New as of 0.3.17
 
 Dokku currently templates out an nginx configuration that is included in the `nginx-vhosts` plugin. If you'd like to provide a custom template for your application, copy the existing template - ssl or non-ssl - into your application's root directory as the file `nginx.conf`. The next time you deploy, Nginx will use your template instead of the default.
 

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -28,6 +28,7 @@ case "$1" in
     if [[ -z "$DOKKU_APP_LISTEN_IP" ]] && [[ -f "$DOKKU_ROOT/$APP/IP" ]]; then
       DOKKU_APP_LISTEN_IP=$(< "$DOKKU_ROOT/$APP/IP")
     fi
+    DOKKU_APP_CONTAINER_ID=$(< "$DOKKU_ROOT/$APP/CONTAINER")
 
     [[ -f "$DOKKU_ROOT/ENV" ]] && source $DOKKU_ROOT/ENV
     [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source $DOKKU_ROOT/$APP/ENV
@@ -76,6 +77,7 @@ EOF
       fi
 
       NOSSL_SERVER_NAME=$(echo $NONSSL_VHOSTS | tr '\n' ' ')
+      docker cp $DOKKU_APP_CONTAINER_ID:/app/nginx.conf $DOKKU_ROOT/$APP/nginx.conf.template 2> /dev/null || true
       APP_NGINX_TEMPLATE="$DOKKU_ROOT/$APP/nginx.conf.template"
       if [[ -f $APP_NGINX_TEMPLATE ]]; then
         dokku_log_info1 "Overriding default nginx.conf with detected nginx.conf.template"


### PR DESCRIPTION
This change allows the application to ship with custom Nginx configuration, instead of having to separately install it in the application directory.

If the application includes a file called `nginx.conf`, that file will be used as template for creating the actual Nginx configuration file.
