### PR TITLE
Nginx configuration for running behind load balancer

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -43,6 +43,28 @@ dokku nginx:import-ssl myapp < archive-of-certs.tar
 
 This archive should is expanded via `tar xvf`. It should contain `server.crt` and `server.key`.
 
+
+## Running behind a load balancer
+
+> New as of 0.3.17
+
+Your application has access to the HTTP headers `X-Forwarded-Proto`, `X-Forwarded-For` and `X-Forwarded-Port`. These headers indicate the protocol of the original request (HTTP or HTTPS), the port number, and the IP address of the client making the request, respectively. The default configuration is for Nginx to set these headers.
+
+If your server runs behind an HTTP/S load balancer, then Nginx will see all requests as coming from the load balancer. If your load balancer sets the `X-Forwarded-` headers, you can tell Nginx to pass these headers from load balancer to your application by setting the `DOKKU_SSL_TERMINATED` environment variable:
+
+```shell
+dokku config:set myapp DOKKU_SSL_TERMINATED=1
+```
+
+Only use this option if:
+1. All requests are terminated at the load balancer, and forwarded to Nginx
+2. The load balancer is configured to send the `X-Forwarded-` headers (this may be off by default)
+
+If it's possible to make HTTP/S requests directly to Nginx, bypassing the load balancer, or if the load balancer is not configured to set these headers, then it becomes possible for a client to set these headers to arbitrary values.
+
+This could result in security issue, for example, if your application looks at the value of the `X-Forwarded-Proto` to determine if the request was made over HTTPS.
+
+
 ## Customizing the nginx configuration
 
 > New as of 0.3.10

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -82,7 +82,11 @@ EOF
         eval "cat <<< \"$(< $APP_NGINX_TEMPLATE)\" > $NGINX_CONF"
       elif [[ -n "$NONSSL_VHOSTS" ]]; then
         xargs -i echo "-----> Configuring {}..." <<< "$NONSSL_VHOSTS"
-        NGINX_TEMPLATE="$PLUGIN_PATH/nginx-vhosts/templates/nginx.conf"
+        if [[ -n "$DOKKU_SSL_TERMINATED" ]]; then
+          NGINX_TEMPLATE="$PLUGIN_PATH/nginx-vhosts/templates/nginx.terminated.conf"
+        else
+          NGINX_TEMPLATE="$PLUGIN_PATH/nginx-vhosts/templates/nginx.conf"
+        fi
         eval "cat <<< \"$(< $NGINX_TEMPLATE)\" >> $NGINX_CONF"
       fi
 

--- a/plugins/nginx-vhosts/templates/nginx.terminated.conf
+++ b/plugins/nginx-vhosts/templates/nginx.terminated.conf
@@ -1,0 +1,19 @@
+# Nginx configuration when running behind a load balancer that terminates SSL
+# connections (e.g. AWS ELB)
+server {
+  listen      [::]:80;
+  listen      80;
+  server_name $NOSSL_SERVER_NAME;
+  location    / {
+    proxy_pass  http://$APP;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host \$http_host;
+    proxy_set_header X-Forwarded-Proto \$http_x_forwarded_proto;
+    proxy_set_header X-Forwarded-For \$http_x_forwarded_for;
+    proxy_set_header X-Forwarded-Port \$http_x_forwarded_port;
+    proxy_set_header X-Request-Start \$msec;
+  }
+  include $DOKKU_ROOT/$APP/nginx.conf.d/*.conf;
+}


### PR DESCRIPTION
When running behind a load balancer that terminates SSL connections (e.g. AWS ELB), Nginx must pass the X-Forwarded headers from the load balancer to the application.

When Nginx is terminating SSL connections, it must not trust any headers sent from the client, and must set those directly.

This PR adds a new setting `DOKKU_SSL_TERMINATED` that, when set, will pick the Nginx configuration that supports a load balancer that terminates SSL connections.