### PR TITLE
minor dev env cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ include deb.mk
 all:
 	# Type "make install" to install.
 
-install: dependencies stack copyfiles plugin-dependencies plugins version
+install: dependencies copyfiles plugin-dependencies plugins version
 
 release: deb-all package_cloud packer
 
@@ -61,7 +61,8 @@ plugin-dependencies: pluginhook
 plugins: pluginhook docker
 	dokku plugins-install
 
-dependencies: sshcommand pluginhook docker stack help2man
+dependencies: sshcommand pluginhook docker help2man
+	$(MAKE) -e stack
 
 help2man:
 	apt-get install -qq -y help2man

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ DOKKU_IP = ENV["DOKKU_IP"] || "10.0.0.2"
 PREBUILT_STACK_URL = File.exist?("#{File.dirname(__FILE__)}/stack.tgz") ? 'file:///root/dokku/stack.tgz' : nil
 PUBLIC_KEY_PATH = "#{Dir.home}/.ssh/id_rsa.pub"
 
-make_cmd = "make install"
+make_cmd = "DEBIAN_FRONTEND=noninteractive make -e install"
 if PREBUILT_STACK_URL
   make_cmd = "PREBUILT_STACK_URL='#{PREBUILT_STACK_URL}' #{make_cmd}"
 end
@@ -35,7 +35,7 @@ Vagrant::configure("2") do |config|
     vm.vm.network :forwarded_port, guest: 80, host: 8080
     vm.vm.hostname = "#{DOKKU_DOMAIN}"
     vm.vm.network :private_network, ip: DOKKU_IP
-    vm.vm.provision :shell, :inline => "apt-get -qq -y install git > /dev/null && cd /root/dokku && #{make_cmd}"
+    vm.vm.provision :shell, :inline => "DEBIAN_FRONTEND=noninteractive apt-get -qq -y install git > /dev/null && cd /root/dokku && #{make_cmd}"
     vm.vm.provision :shell, :inline => "cd /root/dokku && make dokku-installer"
   end
 
@@ -47,7 +47,7 @@ Vagrant::configure("2") do |config|
   end
 
   config.vm.define "build", autostart: false do |vm|
-    vm.vm.provision :shell, :inline => "apt-get -qq -y install git > /dev/null && cd /root/dokku && #{make_cmd}"
+    vm.vm.provision :shell, :inline => "DEBIAN_FRONTEND=noninteractive apt-get -qq -y install git > /dev/null && cd /root/dokku && #{make_cmd}"
     vm.vm.provision :shell, :inline => "cd /root/dokku && make deb-all"
   end
 


### PR DESCRIPTION
Since #936, the dev environment has imported the buildstep image from docker's hub as `ifdef` statements get executed at make runtime and not at target execution time. Therefore the `ifdef` on line 98 was always false. Calling `$(MAKE) -e stack` instead, solves this.

also quiets this message:
  
  ```
  ==> dokku: dpkg-preconfigure: unable to re-open stdin: No such file or directory
  ```

