### PR TITLE
Better/check

### DIFF
--- a/dokku
+++ b/dokku
@@ -97,10 +97,9 @@ case "$1" in
     }
 
     # Wait until the port is bound on the docker host
-    echo -n "waiting for TCP connection to $ipaddr:$port..."
+    dokku_log_info1 "Waiting for [$ipaddr]:$port to come online"
     while ! nc -w 1 $ipaddr $port 2>/dev/null
     do
-      echo -n .
       sleep 1
     done
 

--- a/dokku
+++ b/dokku
@@ -97,7 +97,7 @@ case "$1" in
     }
 
     # Wait until the port is bound on the docker host
-    dokku_log_info1 "Waiting for [$ipaddr]:$port to come online"
+    dokku_log_verbose "Waiting for $APP to come online"
     while ! nc -w 1 $ipaddr $port 2>/dev/null
     do
       sleep 1

--- a/dokku
+++ b/dokku
@@ -96,6 +96,14 @@ case "$1" in
       kill -9 $$
     }
 
+    # Wait until the port is bound on the docker host
+    echo -n "waiting for TCP connection to $ipaddr:$port..."
+    while ! nc -w 1 $ipaddr $port 2>/dev/null
+    do
+      echo -n .
+      sleep 1
+    done
+
     # run checks first, then post-deploy hooks, which switches Nginx traffic
     trap kill_new INT TERM EXIT
     dokku_log_info1 "Running pre-flight checks"

--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -72,18 +72,7 @@ cleanup() {
 trap cleanup EXIT
 
 if [[ ! -s "${TMPDIR}/CHECKS" ]] ; then
-  dokku_log_verbose "CHECKS file not found in container: running simple container check..."
-  rm -rf $TMPDIR
-
-  # simple default check to see if the container stuck around
-  # for more thorough checks, create a CHECKS file
-  #
-  DOKKU_DEFAULT_WAIT=$((WAIT+TIMEOUT))
-  dokku_log_info1 "Waiting for $DOKKU_DEFAULT_WAIT seconds ..."
-  sleep $DOKKU_DEFAULT_WAIT
-
-  docker ps -q --no-trunc | grep -q "$DOKKU_APP_CONTAINER_ID" || dokku_log_fail "App container failed to start!!"
-  dokku_log_info1 "Default container check successful!" && exit 0
+  dokku_log_verbose "CHECKS file not found in container." && exit 0
 fi
 
 # Reads name/value pairs, sets the WAIT and TIMEOUT variables

--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -77,6 +77,7 @@ if [[ ! -s "${TMPDIR}/CHECKS" ]] ; then
 
   # simple default check to see if the container stuck around
   # for more thorough checks, create a CHECKS file
+  #
   DOKKU_DEFAULT_WAIT=$((WAIT+TIMEOUT))
   dokku_log_info1 "Waiting for $DOKKU_DEFAULT_WAIT seconds ..."
   sleep $DOKKU_DEFAULT_WAIT


### PR DESCRIPTION
This PR solves: https://github.com/progrium/dokku/issues/1070. The deploy will wait for the container to start accepting TCP requests, effectively creating a zero-downtime dokku. It's based on: https://github.com/aanand/docker-wait/blob/master/wait

The `nc` dependency is available on ubuntu and inside of the buildpacks (well atleast the node one):

I do not think this PR is complete, but I wanted some feedback on the direction / implementation. Some improvements include:

- Testing (not sure how to test dokku atm)
- A timeout (so we don't end up in an infinite loop)
- Remove `nc` (is that possible?)
- Move to the checks plugin

I do think checks and this are not mutually exclusive, I think you'd want both to make sure your application has been deployed correctly.