### PR TITLE
Better detection of dokku remote

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -46,7 +46,7 @@ if [[ ! -z $DOKKU_HOST ]]; then
     appname=""
     if [[ -d .git ]] || git rev-parse --git-dir > /dev/null 2>&1; then
       set +e
-      appname=$(git remote -v 2>/dev/null | grep -Ei "^dokku" | head -n 1 | cut -f1 -d' ' | cut -f2 -d':' 2>/dev/null)
+      appname=$(git remote -v 2>/dev/null | grep -Ei "dokku@$DOKKU_HOST" | head -n 1 | cut -f1 -d' ' | cut -f2 -d':' 2>/dev/null)
       set -e
     else
       echo "This is not a git repository"


### PR DESCRIPTION
Previously this script was matching for a remote named 'dokku' even
when DOKKU_HOST is provided and completely custom. I have a case where
I have 2 remotes with dokku, one on a staging server and another on a
production server.
So by matching for 'dokku@$DOKKU_HOST' instead, the script can determine
correctly which remote to use.