### PR TITLE
TTY and Compression for SSH

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -94,7 +94,7 @@ if [[ ! -z $DOKKU_HOST ]]; then
     fi
 
     if [[ -z "$donotshift" ]]; then
-      ssh "dokku@$DOKKU_HOST" "$@"
+      ssh -t "dokku@$DOKKU_HOST" "$@"
       exit $?
     fi
 
@@ -116,7 +116,7 @@ if [[ ! -z $DOKKU_HOST ]]; then
       fi
     fi
     # shellcheck disable=SC2086
-    ssh "dokku@$DOKKU_HOST" $long_args "$verb" "$appname" "${args[@]}"
+    ssh -t "dokku@$DOKKU_HOST" $long_args "$verb" "$appname" "${args[@]}"
   }
 
   if [[ "$0" == "dokku" ]] || [[ "$0" == *dokku_client.sh ]]; then


### PR DESCRIPTION
When using commands requiring a TTY (such as Rails console), this
script won’t work.
So enabling a TTY resolves the issue. Also compression should be
enabled by default I think.