### PR TITLE
corrected configuration link in bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -33,4 +33,5 @@ make install
 
 echo
 echo "Almost done! For next steps on configuration:"
-echo "  http://progrium.viewdocs.io/dokku/installation#user-content-configuring"
+echo "  http://progrium.viewdocs.io/dokku/advanced-installation#user-content-configuring"
+


### PR DESCRIPTION
The bootstraph.sh file contained an old link. I saw it when it was mentioned in issue [#985](https://github.com/progrium/dokku/issues/985) though it does not solve the actual issue there. I have updated the link to avoid confusion. 

The previous link was http://progrium.viewdocs.io/dokku/installation#user-content-configuring and it is now http://progrium.viewdocs.io/dokku/advanced-installation#user-content-configuring

Thanks

Rory