### PR TITLE
Make port forwarding configurable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ BOX_URI = ENV["BOX_URI"] || "https://cloud-images.ubuntu.com/vagrant/trusty/curr
 BOX_MEMORY = ENV["BOX_MEMORY"] || "1024"
 DOKKU_DOMAIN = ENV["DOKKU_DOMAIN"] || "dokku.me"
 DOKKU_IP = ENV["DOKKU_IP"] || "10.0.0.2"
+FORWARDED_PORT = (ENV["FORWARDED_PORT"] || '8080').to_i
 PREBUILT_STACK_URL = File.exist?("#{File.dirname(__FILE__)}/stack.tgz") ? 'file:///root/dokku/stack.tgz' : nil
 PUBLIC_KEY_PATH = "#{Dir.home}/.ssh/id_rsa.pub"
 
@@ -32,7 +33,7 @@ Vagrant::configure("2") do |config|
   config.vm.define "empty", autostart: false
 
   config.vm.define "dokku", primary: true do |vm|
-    vm.vm.network :forwarded_port, guest: 80, host: 8080
+    vm.vm.network :forwarded_port, guest: 80, host: FORWARDED_PORT
     vm.vm.hostname = "#{DOKKU_DOMAIN}"
     vm.vm.network :private_network, ip: DOKKU_IP
     vm.vm.provision :shell, :inline => "apt-get -qq -y install git > /dev/null && cd /root/dokku && #{make_cmd}"
@@ -40,7 +41,7 @@ Vagrant::configure("2") do |config|
   end
 
   config.vm.define "dokku-deb", autostart: false do |vm|
-    vm.vm.network :forwarded_port, guest: 80, host: 8080
+    vm.vm.network :forwarded_port, guest: 80, host: ENV['FORWARDED_PORT']
     vm.vm.hostname = "#{DOKKU_DOMAIN}"
     vm.vm.network :private_network, ip: DOKKU_IP
     vm.vm.provision :shell, :inline => "cd /root/dokku && make install-from-deb"

--- a/docs/getting-started/install/vagrant.md
+++ b/docs/getting-started/install/vagrant.md
@@ -21,7 +21,8 @@
     # - `BOX_URI`
     # - `BOX_MEMORY`
     # - `DOKKU_DOMAIN`
-    # - `DOKKU_IP`.
+    # - `DOKKU_IP`
+    # - `FORWARDED_PORT`.
     cd path/to/dokku
     vagrant up
     ```


### PR DESCRIPTION
My first attempt to build the Vagrant VM resulted in this error:

```
Vagrant cannot forward the specified ports on this VM, since they
would collide with some other application that is already listening
on these ports. The forwarded port to 8080 is already in use
on the host machine.
```

because I already had another VM listening on 8080.

This change enables devs to avoid port collisions by specifying:

    FORWARDED_PORT=8091 vagrant up