### PR TITLE
added two more cases to SSL template and gzip as default in templates.

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.conf.template
+++ b/plugins/nginx-vhosts/templates/nginx.conf.template
@@ -3,6 +3,14 @@ server {
   listen      80;
   server_name $NOSSL_SERVER_NAME;
   location    / {
+
+    gzip on;
+    gzip_min_length  1100;
+    gzip_buffers  4 32k;
+    gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+    gzip_vary on;
+    gzip_comp_level  6;
+
     proxy_pass  http://$APP;
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;

--- a/plugins/nginx-vhosts/templates/nginx.ssl.conf.template
+++ b/plugins/nginx-vhosts/templates/nginx.ssl.conf.template
@@ -49,6 +49,3 @@ $SSL_DIRECTIVES
   }
   include $DOKKU_ROOT/$APP/nginx.conf.d/*.conf;
 }
-
-
-

--- a/plugins/nginx-vhosts/templates/nginx.ssl.conf.template
+++ b/plugins/nginx-vhosts/templates/nginx.ssl.conf.template
@@ -6,6 +6,21 @@ server {
 }
 
 server {
+  listen      [::]:80;
+  listen      80;
+  server_name $SSL_SERVER_NAME;
+  return 301 https://$SSL_SERVER_NAME$request_uri;
+}
+
+server {
+  listen      [::]:80;
+  listen      80;
+  server_name www.$SSL_SERVER_NAME;
+  return 301 https://www.$SSL_SERVER_NAME$request_uri;
+}
+
+
+server {
   listen      [::]:443 ssl spdy;
   listen      443 ssl spdy;
   server_name $SSL_SERVER_NAME;
@@ -14,6 +29,14 @@ $SSL_DIRECTIVES
   keepalive_timeout   70;
   add_header          Alternate-Protocol  443:npn-spdy/2;
   location    / {
+
+    gzip on;
+    gzip_min_length  1100;
+    gzip_buffers  4 32k;
+    gzip_types    text/css text/javascript text/xml text/plain text/x-component application/javascript application/x-javascript application/json application/xml  application/rss+xml font/truetype application/x-font-ttf font/opentype application/vnd.ms-fontobject image/svg+xml;
+    gzip_vary on;
+    gzip_comp_level  6;
+
     proxy_pass  http://$APP;
     proxy_http_version 1.1;
     proxy_set_header Upgrade \$http_upgrade;
@@ -26,3 +49,6 @@ $SSL_DIRECTIVES
   }
   include $DOKKU_ROOT/$APP/nginx.conf.d/*.conf;
 }
+
+
+


### PR DESCRIPTION
There were two cases missing from the SSL template:

1) Ability to redirect from www to https://www
2) Ability to redirect from naked url to https://

And added gzip as default on both SSL and NOSSL templates.