### PR TITLE
Logging info suggesting tuned CHECKS

### DIFF
--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -78,7 +78,11 @@ cleanup() {
 trap cleanup EXIT
 
 if [[ ! -s "${TMPDIR}/CHECKS" ]] ; then
-  dokku_log_verbose "CHECKS file not found in container: running simple container check..."
+  dokku_log_verbose "CHECKS file not found in container:"
+  dokku_log_verbose "Running simple container check..."
+  dokku_log_verbose "For more efficient Zero Downtime deployments, tune your CHECKS. See:"
+  dokku_log_verbose "http://progrium.viewdocs.io/dokku/checks-examples.md for examples"
+
   rm -rf $TMPDIR
 
   # simple default check to see if the container stuck around

--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -78,10 +78,9 @@ cleanup() {
 trap cleanup EXIT
 
 if [[ ! -s "${TMPDIR}/CHECKS" ]] ; then
-  dokku_log_verbose "CHECKS file not found in container:"
-  dokku_log_verbose "Running simple container check..."
-  dokku_log_verbose "For more efficient Zero Downtime deployments, tune your CHECKS. See:"
-  dokku_log_verbose "http://progrium.viewdocs.io/dokku/checks-examples.md for examples"
+  dokku_log_verbose "For more efficient zero downtime deployments, create a file CHECKS."
+  dokku_log_verbose "See http://progrium.viewdocs.io/dokku/checks-examples.md for examples"
+  dokku_log_verbose "CHECKS file not found in container: Running simple container check..."
 
   rm -rf $TMPDIR
 


### PR DESCRIPTION
Added log info that shows up when default check is used:
````
CHECKS file not found in container:
Running simple container check...
For more efficient Zero Downtime deployments, tune your CHECKS. See:
http://progrium.viewdocs.io/dokku/checks-examples.md for examples
````
