### PR TITLE
Safer installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Docker powered mini-Heroku. The smallest PaaS implementation you've ever seen. S
 
 ## Installing
 
-To install the latest stable release, you can run the following command as a user that has access to `sudo`:
+To install the latest stable release, you can run the following commands as a user that has access to `sudo`:
 
-    wget -qO- https://raw.github.com/progrium/dokku/v0.3.17/bootstrap.sh | sudo DOKKU_TAG=v0.3.17 bash
+    wget https://raw.github.com/progrium/dokku/v0.3.17/bootstrap.sh
+    sudo DOKKU_TAG=v0.3.17 bash bootstrap.sh
 
 ### Upgrading
 


### PR DESCRIPTION
Piping the output of `curl` or `wget -O-` to a shell is a very bad idea for multiple reasons; security concerns aside, doing so provides no opportunity for the script's download to finish before execution starts, so if the download is interrupted for some reason (perhaps because of an intermittent network failure), the incompletely-downloaded script will still run with potentially disastrous results.  See [here](http://www.seancassidy.me/dont-pipe-to-your-shell.html) for a more in-depth description.