### PR TITLE
Add information about 444 for nginx in default_sever.

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -167,7 +167,7 @@ d6499edb0edb        dokku/node-js-app:latest   "/bin/bash -c '/star   About a mi
 
 # Default site
 
-By default, dokku will route any received request with an unknown HOST header value to the lexicographically first site in the nginx config stack. If this is not the desired behavior, you may want to add the following configuration to nginx. This will catch all unknown HOST header values and return a `410 Gone` response.
+By default, dokku will route any received request with an unknown HOST header value to the lexicographically first site in the nginx config stack. If this is not the desired behavior, you may want to add the following configuration to nginx. This will catch all unknown HOST header values and return a `410 Gone` response. You can replace the `return 410;` with `return 444;` which will cause nginx to not respond to requests that do not match known domains (connection refused).
 
 ```
 server {


### PR DESCRIPTION
Something I would've found helpful. Also I'm not a fan of using 410 over 404. Not sure how that handles with SEO if I were to decide to use a site on that domain. 404 is the default behavior of NGINX.