### PR TITLE
pluginhook to receive branches different than master

### DIFF
--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -39,8 +39,12 @@ case "$1" in
         # broken out into pluginhook so we might support other methods to receive an app
         pluginhook receive-app $APP $newrev
       else
-        echo $'\e[1G\e[K'"-----> WARNING: deploy did not complete, you must push to master."
-        echo $'\e[1G\e[K'"-----> for example, try 'git push <dokku> ${refname/refs\/heads\/}:master'"
+        if test -f "$PLUGIN_PATH"/enabled/*/receive-branch; then
+          pluginhook receive-branch $APP $newrev $refname
+        else
+          echo $'\e[1G\e[K'"-----> WARNING: deploy did not complete, you must push to master."
+          echo $'\e[1G\e[K'"-----> for example, try 'git push <dokku> ${refname/refs\/heads\/}:master'"
+        fi
       fi
     done
     ;;


### PR DESCRIPTION
I need an option to receive multiple versions of the same application in an easy for the developer way (so branches instead of remotes). This patch allows me to do this:

```bash
#!/bin/bash

reference_app=$1
refname=$3
newrev=$2
APP=${refname/*\//}.$reference_app

if [[ ! -d "$DOKKU_ROOT/$APP" ]]; then
  REFERENCE_REPO="$DOKKU_ROOT/$reference_app
  git clone --bare --shared --reference "$REFERENCE_REPO" "$REFERENCE_REPO" "$DOKKU_ROOT/$APP" > /dev/null
fi
pluginhook receive-app $APP $newrev
```

I would leave the warning in the code but I don’t know how to check if any plugin handled the event. I’d use the same approach as with `DOKKU_NOT_IMPLEMENTED_EXIT`, but it’s too much hassle.