### PR TITLE
Allow to kill new container that failed CHECKS

### DIFF
--- a/dokku
+++ b/dokku
@@ -91,7 +91,7 @@ case "$1" in
 
     # if we can't post-deploy successfully, kill new container
     kill_new() {
-      docker inspect $id &> /dev/null && docker stop $id > /dev/null && docker kill $id > /dev/null
+      docker inspect $id &> /dev/null && docker kill $id > /dev/null
       trap - INT TERM EXIT
       kill -9 $$
     }


### PR DESCRIPTION
When the check does not pass there is no reason to close the container
in the correct way. We can do this by using SIGKILL signal.

Related: #1151