### PR TITLE
Add curl to install-from-deb make command

### DIFF
--- a/deb.mk
+++ b/deb.mk
@@ -31,7 +31,7 @@ GOPATH = /home/vagrant/gocode
 install-from-deb:
 	echo "--> Initial apt-get update"
 	sudo apt-get update > /dev/null
-	sudo apt-get install -y apt-transport-https
+	sudo apt-get install -y apt-transport-https curl
 
 	echo "--> Installing docker gpg key"
 	curl --silent https://get.docker.com/gpg 2> /dev/null | apt-key add - 2>&1 >/dev/null


### PR DESCRIPTION
install-from-deb doesn't install curl, while it's needed to add the Docker GPG keys.

This also fixes provisioning on the Vagrant dokku-deb box, as that uses install-from-deb.