### PR TITLE
[RFC] Use debconf for package configuration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 # If you're submitting a patch, please add your name here in alphabetical order as part of the patch.
 # This file lists all individuals having contributed content to the repository.
 #
+3onyc <3onyc@x3tech.com>
 Alexander <iam.asm89@gmail.com>
 Alexander Beletsky <alexander.beletsky@gmail.com>
 Alexis Gavoty <kload@kload.fr>

--- a/debian/config
+++ b/debian/config
@@ -1,0 +1,21 @@
+#!/bin/sh -e
+
+. /usr/share/debconf/confmodule
+
+readonly ACTION="${1:-configure}"
+readonly VERSION="${2:-dev}"
+
+db_input "high" "dokku/web_config" || true
+db_go || true
+
+db_get "dokku/web_config"
+if [ $RET = "true" ]; then
+    exit 0
+fi
+
+db_input "high" "dokku/hostname" || true
+db_input "high" "dokku/vhost_enable" || true
+if [ "$ACTION" != "reconfigure" ]; then
+  db_input "high" "dokku/key_file" || true
+fi
+db_go || true

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+. /usr/share/debconf/confmodule
+
+readonly DOKKU_ROOT="${DOKKU_ROOT:-/home/dokku}"
+
 case "$1" in
   abort-upgrade|abort-remove|abort-deconfigure)
     ;;
@@ -18,6 +22,27 @@ case "$1" in
 
     if [ -f /etc/init/dokku-installer.conf ] && service dokku-installer status 2> /dev/null | grep waiting; then
         sudo service dokku-installer start
+    fi
+
+    db_get "dokku/web_config"
+    if [ "$RET" = "true" ]; then
+      exit 0
+    fi
+
+    db_get "dokku/vhost_enable"
+    if [ "$RET" = "true" ]; then
+        db_get "dokku/hostname" 
+        echo "$RET" > "${DOKKU_ROOT}/VHOST"
+    else
+        rm -f "${DOKKU_ROOT}/VHOST"
+    fi
+
+    db_get "dokku/hostname"
+    echo "$RET" > "${DOKKU_ROOT}/HOSTNAME"
+
+    if [ -z "${DEBCONF_RECONFIGURE}" ]; then
+      db_get "dokku/key_file"
+      sshcommand acl-add dokku default < "$RET"
     fi
     ;;
 

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,8 +1,25 @@
 #!/bin/sh
 set -e
 
+. /usr/share/debconf/confmodule
+
 case "$1" in
   install)
+    if [ -z "${DEBCONF_RECONFIGURE}" ]; then
+      db_get "dokku/key_file"
+      if [ ! -f "$RET" ]; then
+          echo "Error: keyfile '$RET' not found."
+          echo "       you can enter a new keyfile path when you restart the installation."
+          db_reset "dokku/key_file"
+          exit 1
+      fi
+    fi
+
+    db_get "dokku/web_config"
+    if [ "$RET" = "false" ]; then
+      exit 0
+    fi
+
     INIT_CONF="/etc/init/dokku-installer.conf"
     NGINX_CONF="/etc/nginx/conf.d/dokku-installer.conf"
 

--- a/debian/templates
+++ b/debian/templates
@@ -1,0 +1,19 @@
+Template: dokku/web_config
+Description: Use the web-based config page?
+Type: boolean
+Default: true
+
+Template: dokku/vhost_enable
+Description: Use vhost based deployments?
+Type: boolean
+Default: false
+
+Template: dokku/hostname
+Description: Machine's hostname or IP
+Type: string
+Default: dokku.me
+
+Template: dokku/key_file
+Description: Keyfile for initial user
+Type: string
+Default: /root/.ssh/id_rsa.pub

--- a/docs/getting-started/install/debian.md
+++ b/docs/getting-started/install/debian.md
@@ -13,3 +13,24 @@ sudo apt-get update > /dev/null
 sudo apt-get install -qq -y linux-image-extra-`uname -r` apt-transport-https
 sudo apt-get install -qq -y dokku
 ```
+
+## Unattended installation
+
+In case you want to perform an unattended installation of dokku, this is made possible through [debconf](https://en.wikipedia.org/wiki/Debconf_%28software_package%29), which allows you to configure a package before installing it.
+
+You can set any of the below options through the `debconf-set-selections` command, for example to enable vhost-based deployments:
+
+```bash
+echo "dokku dokku/vhost_enable boolean true" | debconf-set-selections
+```
+
+After setting the desired options, proceed with the installation as described above.
+
+### debconf options
+
+| Name               | Type    | Default               | Description                                                              |
+| ------------------ | ------- | --------------------- | ------------------------------------------------------------------------ |
+| dokku/web_config   | boolean | true                  | Use web-based config for below options                                   |
+| dokku/vhost_enable | boolean | false                 | Use vhost-based deployments (e.g. <app>.dokku.me)                        |
+| dokku/hostname     | string  | dokku.me              | Hostname, used as vhost domain and for showing app URL after deploy      |
+| dokku/key_file     | string  | /root/.ssh/id_rsa.pub | SSH key to add to the Dokku user (Will be ignored on `dpkg-reconfigure`) |


### PR DESCRIPTION
This PR implements debconf to allow for command-line or unattended installation.

### Config variables

| Name | Type | Default | Description |
| ------- | ------ | ---------- | -------------- |
| dokku/web_config | boolean | true | Use web-based config, if yes other options will be skipped |
| dokku/vhost_enable | boolean | false | Use vhost based deployments or not |
| dokku/hostname | string | dokku.me | Hostname that Dokku should use |
| dokku/key_file | string | /root/.ssh/id_rsa.pub | Key to add to the Dokku user (Will not be asked on `dpkg-reconfigure` |

### How to pre-seed variables

```shell
debconf-set-selections <<< "dokku dokku/web_config boolean false"
```

### Installation workflow
*Note: this uses my own PackageCloud repository, as that has the updated packages*

```shell
#!/bin/bash

# Do your debconf-set-selections stuff here
# debconf-set-selections <<< "dokku dokku/web_config boolean false"

apt-get update -qqy
apt-get install -qqy curl

curl --silent https://get.docker.io/gpg | apt-key add - >/dev/null
curl --silent https://packagecloud.io/gpg.key | apt-key add - >/dev/null

echo "deb http://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
echo "deb https://packagecloud.io/x3tech/dokku/ubuntu/ trusty main" > /etc/apt/sources.list.d/dokku.list

apt-get update -qqy
apt-get install -qqy linux-image-extra-`uname -r` apt-transport-https dokku
```

Related Issues:
* #1161 

Progress:

- [x] Configuration through debconf is implemented
- [x] Part of logic to handle configuration
- [x] Logic for switching from vhost to non-vhost config 
- [x] Don't ask for ssh key to import on reconfigure