### PR TITLE
unify default and custom nginx template processing

### DIFF
--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -33,6 +33,7 @@ case "$1" in
     URLS_PATH="$DOKKU_ROOT/$APP/URLS"
     WILDCARD_SSL="$DOKKU_ROOT/tls"
     SSL="$DOKKU_ROOT/$APP/tls"
+    APP_NGINX_TEMPLATE="$DOKKU_ROOT/$APP/nginx.conf.template"
 
     if [[ -z "$DOKKU_APP_LISTEN_PORT" ]] && [[ -f "$DOKKU_ROOT/$APP/PORT" ]]; then
       DOKKU_APP_LISTEN_PORT=$(< "$DOKKU_ROOT/$APP/PORT")
@@ -43,6 +44,7 @@ case "$1" in
 
     [[ -f "$DOKKU_ROOT/ENV" ]] && source $DOKKU_ROOT/ENV
     [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source $DOKKU_ROOT/$APP/ENV
+    [[ -f "$APP_NGINX_TEMPLATE" ]] && NGINX_TEMPLATE="$APP_NGINX_TEMPLATE" && NGINX_CUSTOM_TEMPLATE="true"
 
     if [[ ! -n "$NO_VHOST" ]] && [[ -f "$DOKKU_ROOT/$APP/VHOST" ]]; then
       NONSSL_VHOSTS=$(cat $VHOST_PATH)
@@ -63,6 +65,7 @@ EOF
       if [[ -n "$SSL_INUSE" ]]; then
         SCHEME="https"
 
+        [[ -z "$NGINX_TEMPLATE" ]] && NGINX_TEMPLATE="$PLUGIN_PATH/nginx-vhosts/templates/nginx.ssl.conf.template"
         SSL_HOSTNAME=$(openssl x509 -in $SSL_INUSE/server.crt -noout -subject | tr '/' '\n' | grep CN= | cut -c4-)
         if [[ -n "$SSL_HOSTNAME" ]]; then
           SSL_HOSTNAME_REGEX=$(echo "$SSL_HOSTNAME" | sed 's|\.|\\.|g' | sed 's/\*/\[^\.\]\*/g')
@@ -76,9 +79,8 @@ EOF
         fi
 
         SSL_VHOSTS=$(egrep "^${SSL_HOSTNAME_REGEX}$|^${SSL_HOSTNAME_ALT_REGEX}$" $VHOST_PATH || exit 0)
-        NONSSL_VHOSTS=$(egrep -v "^${SSL_HOSTNAME}$|^${SSL_HOSTNAME_ALT}$" $VHOST_PATH || exit 0)
+        NONSSL_VHOSTS=$(egrep -v "^${SSL_HOSTNAME_REGEX}$|^${SSL_HOSTNAME_ALT_REGEX}$" $VHOST_PATH || exit 0)
 
-        NGINX_TEMPLATE="$PLUGIN_PATH/nginx-vhosts/templates/nginx.ssl.conf.template"
         while read line; do
           dokku_log_info1 "Configuring SSL for $line..."
           SSL_SERVER_NAME=$line
@@ -87,14 +89,10 @@ EOF
         done <<< "$SSL_VHOSTS"
       fi
 
-      NOSSL_SERVER_NAME=$(echo $NONSSL_VHOSTS | tr '\n' ' ')
-      APP_NGINX_TEMPLATE="$DOKKU_ROOT/$APP/nginx.conf.template"
-      if [[ -f $APP_NGINX_TEMPLATE ]]; then
-        dokku_log_info1 "Overriding default nginx.conf with detected nginx.conf.template"
-        eval "cat <<< \"$(< $APP_NGINX_TEMPLATE)\" > $NGINX_CONF"
-      elif [[ -n "$NONSSL_VHOSTS" ]]; then
+      if [[ -n "$NONSSL_VHOSTS" ]]; then
+        NOSSL_SERVER_NAME=$(echo $NONSSL_VHOSTS | tr '\n' ' ')
         xargs -i echo "-----> Configuring {}..." <<< "$NONSSL_VHOSTS"
-        NGINX_TEMPLATE="$PLUGIN_PATH/nginx-vhosts/templates/nginx.conf.template"
+        [[ -z "$NGINX_CUSTOM_TEMPLATE" ]] && NGINX_TEMPLATE="$PLUGIN_PATH/nginx-vhosts/templates/nginx.conf.template"
         eval "cat <<< \"$(< $NGINX_TEMPLATE)\" >> $NGINX_CONF"
       fi
 

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -44,7 +44,7 @@ case "$1" in
 
     [[ -f "$DOKKU_ROOT/ENV" ]] && source $DOKKU_ROOT/ENV
     [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source $DOKKU_ROOT/$APP/ENV
-    [[ -f "$APP_NGINX_TEMPLATE" ]] && NGINX_TEMPLATE="$APP_NGINX_TEMPLATE" && NGINX_CUSTOM_TEMPLATE="true"
+    [[ -f "$APP_NGINX_TEMPLATE" ]] && NGINX_TEMPLATE="$APP_NGINX_TEMPLATE" && NGINX_CUSTOM_TEMPLATE="true" && dokku_log_info1 'Overriding default nginx.conf with detected nginx.conf.template'
 
     if [[ ! -n "$NO_VHOST" ]] && [[ -f "$DOKKU_ROOT/$APP/VHOST" ]]; then
       NONSSL_VHOSTS=$(cat $VHOST_PATH)

--- a/tests/unit/nginx-vhosts.bats
+++ b/tests/unit/nginx-vhosts.bats
@@ -72,8 +72,25 @@ assert_http_success() {
   assert_nonssl_domain "www.test.dokku.me"
 }
 
+@test "(nginx-vhosts) nginx:build-config (wildcard SSL & custom nginx template)" {
+  setup_test_tls_wildcard
+  add_domain "wildcard1.dokku.me"
+  add_domain "wildcard2.dokku.me"
+  custom_ssl_nginx_template
+  deploy_app
+  assert_ssl_domain "wildcard1.dokku.me"
+  assert_ssl_domain "wildcard2.dokku.me"
+}
+
 @test "(nginx-vhosts) nginx:build-config (with SSL CN mismatch)" {
   setup_test_tls
+  deploy_app
+  assert_ssl_domain "node-js-app.dokku.me"
+}
+
+@test "(nginx-vhosts) nginx:build-config (with SSL CN mismatch & custom nginx template)" {
+  setup_test_tls
+  custom_ssl_nginx_template
   deploy_app
   assert_ssl_domain "node-js-app.dokku.me"
 }
@@ -84,6 +101,13 @@ assert_http_success() {
   assert_ssl_domain "test.dokku.me"
   assert_ssl_domain "www.test.dokku.me"
   assert_ssl_domain "www.test.app.dokku.me"
+}
+
+@test "(nginx-vhosts) nginx:build-config (custom nginx template)" {
+  add_domain "www.test.app.dokku.me"
+  custom_nginx_template
+  deploy_app
+  assert_nonssl_domain "www.test.app.dokku.me"
 }
 
 @test "(nginx-vhosts) nginx:build-config (no global VHOST and domains:add)" {

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -160,3 +160,63 @@ disable_tls_wildcard() {
          -e "s:^ssl_certificate_key $DOKKU_ROOT/tls/server.key;:# ssl_certificate_key $DOKKU_ROOT/tls/server.key;:g" /etc/nginx/conf.d/dokku.conf
   kill -HUP "$(< /var/run/nginx.pid)"; sleep 5
 }
+
+custom_ssl_nginx_template() {
+  APP="$1"
+  [[ -z "$APP" ]] && APP="$TEST_APP"
+cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf.template
+server {
+  listen      [::]:80;
+  listen      80;
+  server_name \$NOSSL_SERVER_NAME;
+  return 301 https://\$SSL_SERVER_NAME\\\$request_uri;
+}
+
+server {
+  listen      [::]:443 ssl spdy;
+  listen      443 ssl spdy;
+  server_name \$SSL_SERVER_NAME;
+\$SSL_DIRECTIVES
+
+  keepalive_timeout   70;
+  add_header          Alternate-Protocol  443:npn-spdy/2;
+  location    / {
+    proxy_pass  http://\$APP;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \\\$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host \\\$http_host;
+    proxy_set_header X-Forwarded-Proto \\\$scheme;
+    proxy_set_header X-Forwarded-For \\\$remote_addr;
+    proxy_set_header X-Forwarded-Port \\\$server_port;
+    proxy_set_header X-Request-Start \\\$msec;
+  }
+  include \$DOKKU_ROOT/\$APP/nginx.conf.d/*.conf;
+}
+EOF
+}
+
+custom_nginx_template() {
+  APP="$1"
+  [[ -z "$APP" ]] && APP="$TEST_APP"
+cat<<EOF > $DOKKU_ROOT/$APP/nginx.conf.template
+server {
+  listen      [::]:80;
+  listen      80;
+  server_name \$NOSSL_SERVER_NAME;
+
+  location    / {
+    proxy_pass  http://\$APP;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade \\\$http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host \\\$http_host;
+    proxy_set_header X-Forwarded-Proto \\\$scheme;
+    proxy_set_header X-Forwarded-For \\\$remote_addr;
+    proxy_set_header X-Forwarded-Port \\\$server_port;
+    proxy_set_header X-Request-Start \\\$msec;
+  }
+  include \$DOKKU_ROOT/\$APP/nginx.conf.d/*.conf;
+}
+EOF
+}


### PR DESCRIPTION
- use the same regex to filter `$NONSSL_VHOSTS` as we do for `$SSL_VHOSTS`
- process custom nginx templates in the same way we process default templates

it should be noted that nginx templates are very broken right now. i'll can have a look at templating in a different manner and consolidating ssl/non-ssl in another PR.

closes #1169 