### PR TITLE
Fix docker gpg key installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ docker: aufs
 	apt-get install -qq -y curl
 	egrep -i "^docker" /etc/group || groupadd docker
 	usermod -aG docker dokku
-	curl --silent https://get.docker.com/gpg | apt-key add -
+	curl -sSL https://get.docker.com/gpg | apt-key add -
 	echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 	apt-get update
 ifdef DOCKER_VERSION

--- a/contrib/stackscript.sh
+++ b/contrib/stackscript.sh
@@ -137,10 +137,10 @@ function install_prerequisites {
   sudo apt-get install -qq -y curl > /dev/null 2>&1
 
   logit "Installing docker gpg key"
-  curl --silent https://get.docker.com/gpg 2> /dev/null | apt-key add - > /dev/null 2>&1
+  curl -sSL https://get.docker.com/gpg 2> /dev/null | apt-key add - > /dev/null 2>&1
 
   logit "Installing dokku gpg key"
-  curl --silent https://packagecloud.io/gpg.key 2> /dev/null | apt-key add - > /dev/null 2>&1
+  curl -sSL https://packagecloud.io/gpg.key 2> /dev/null | apt-key add - > /dev/null 2>&1
 
   logit "Running apt-get update"
   sudo apt-get update > /dev/null

--- a/deb.mk
+++ b/deb.mk
@@ -31,10 +31,10 @@ GOPATH = /home/vagrant/gocode
 install-from-deb:
 	echo "--> Initial apt-get update"
 	sudo apt-get update > /dev/null
-	sudo apt-get install -y apt-transport-https
+	sudo apt-get install -y apt-transport-https curl
 
 	echo "--> Installing docker gpg key"
-	curl --silent https://get.docker.com/gpg 2> /dev/null | apt-key add - 2>&1 >/dev/null
+	curl -sSL https://get.docker.com/gpg | apt-key add -
 
 	echo "--> Installing dokku gpg key"
 	curl --silent https://packagecloud.io/gpg.key 2> /dev/null | apt-key add - 2>&1 >/dev/null


### PR DESCRIPTION
[ci skip] ensure we follow redirects and use ssl when grabbing the do…cker gpg key

Also install curl when running `vagrant up dokku-deb`