### PR TITLE
fixes the TLS doc, per app

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,11 @@ Vagrant::configure("2") do |config|
     vb.customize ["modifyvm", :id, "--memory", BOX_MEMORY]
   end
 
+  config.vm.provider :vmware_fusion do |vbox, override|
+    vbox.memory = 1024
+    override.vm.box = "phusion/ubuntu-14.04-amd64"
+  end
+  
   config.vm.define "empty", autostart: false
 
   config.vm.define "dokku", primary: true do |vm|

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -8,9 +8,18 @@ Dokku provides easy TLS/SPDY support out of the box. This can be done app-by-app
 
 ### Per App
 
-To enable TLS connection to to one of your applications, copy or symlink the `.crt` and `.key` files into the application's `/home/dokku/:app/tls` folder (create this folder if it doesn't exist) as `server.crt` and `server.key` respectively.
+To enable TLS connections to to one of your applications, do the following:
 
-Redeployment of the application will be needed to apply TLS configuration. Once it is redeployed, the application will be accessible by `https://` (redirection from `http://` is applied as well).
+* Create a key file and a cert file. 
+ * You can find detailed steps for generating a self-signed certificate at https://devcenter.heroku.com/articles/ssl-certificate-self
+ * If you are not paranoid and need it just for a DEV or STAGING app, you can use http://www.selfsignedcertificate.com/ to generate your 2 files more easily.
+* Rename your files to server.key and server.crt
+* tar these 2 files together, *without* subdirectories. Example: tar cvf cert-key.tar server.crt server.key
+* Install the pair for your app, like this: ssh dokku@ip-of-your-dokku-server nginx:import-ssl < cert-key.tar
+
+You will need to repeat the steps above for each domain used to serve your app. You can't simply create
+a single tar with all key/cert files in it (see https://github.com/progrium/dokku/issues/1195). 
+
 
 ### All Subdomains
 


### PR DESCRIPTION
Unfortunately this pull request also includes a change I did for vmWare. I killed my original fork, created a new one but that change survived (I guess GitHub reuses it). Feel free to get just the doc change and ignore the vmware part.