### PR TITLE
filter out literal wildcard when deploying an unrelated domain. closes #1185

### DIFF
--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -76,19 +76,20 @@ EOF
         SSL_HOSTNAME=$(openssl x509 -in $SSL_INUSE/server.crt -noout -subject | tr '/' '\n' | grep CN= | cut -c4-)
         if [[ -n "$SSL_HOSTNAME" ]]; then
           SSL_HOSTNAME_REGEX=$(echo "$SSL_HOSTNAME" | sed 's|\.|\\.|g' | sed 's/\*/\[^\.\]\*/g')
-          [[ -z "$(egrep "^${SSL_HOSTNAME_REGEX}$" $VHOST_PATH)" ]] && echo "$SSL_HOSTNAME" >> $VHOST_PATH
+          [[ -z "$(egrep "^${SSL_HOSTNAME_REGEX}$" $VHOST_PATH)" ]] && [[ ! "$SSL_HOSTNAME" =~ ^\*.* ]] && echo "$SSL_HOSTNAME" >> $VHOST_PATH
         fi
 
         SSL_HOSTNAME_ALT=$(openssl x509 -in $SSL_INUSE/server.crt -noout -text | grep --after-context=1 '509v3 Subject Alternative Name:' | tail -n 1 | sed -e "s/[[:space:]]*DNS://g"  | tr ',' '\n' || true)
         if [[ -n "$SSL_HOSTNAME_ALT" ]]; then
           SSL_HOSTNAME_ALT_REGEX=$(echo "$SSL_HOSTNAME_ALT" | sed 's|\.|\\.|g' | sed 's/\*/\[^\.\]\*/g')
-          [[ -z "$(egrep "^${SSL_HOSTNAME_ALT_REGEX}$" $VHOST_PATH)" ]] && echo "$SSL_HOSTNAME_ALT" >> $VHOST_PATH
+          [[ -z "$(egrep "^${SSL_HOSTNAME_ALT_REGEX}$" $VHOST_PATH)" ]] && [[ ! "$SSL_HOSTNAME_ALT" =~ ^\*.* ]] && echo "$SSL_HOSTNAME_ALT" >> $VHOST_PATH
         fi
 
         SSL_VHOSTS=$(egrep "^${SSL_HOSTNAME_REGEX}$|^${SSL_HOSTNAME_ALT_REGEX}$" $VHOST_PATH || exit 0)
         NONSSL_VHOSTS=$(egrep -v "^${SSL_HOSTNAME_REGEX}$|^${SSL_HOSTNAME_ALT_REGEX}$" $VHOST_PATH || exit 0)
 
         while read line; do
+          [[ -z "$line" ]] && continue
           dokku_log_info1 "Configuring SSL for $line..."
           SSL_SERVER_NAME=$line
           NOSSL_SERVER_NAME=$line

--- a/tests/unit/nginx-vhosts.bats
+++ b/tests/unit/nginx-vhosts.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 teardown() {
-  destroy_app
+  destroy_app 0 $TEST_APP
   [[ -f "$DOKKU_ROOT/VHOST.bak" ]] && mv "$DOKKU_ROOT/VHOST.bak" "$DOKKU_ROOT/VHOST"
   [[ -f "$DOKKU_ROOT/HOSTNAME.bak" ]] && mv "$DOKKU_ROOT/HOSTNAME.bak" "$DOKKU_ROOT/HOSTNAME"
   disable_tls_wildcard
@@ -80,6 +80,15 @@ assert_http_success() {
   deploy_app
   assert_ssl_domain "wildcard1.dokku.me"
   assert_ssl_domain "wildcard2.dokku.me"
+}
+
+@test "(nginx-vhosts) nginx:build-config (wildcard SSL & unrelated domain)" {
+  destroy_app
+  TEST_APP="${TEST_APP}.example.com"
+  setup_test_tls_wildcard
+  deploy_app nodejs-express dokku@dokku.me:$TEST_APP
+  run /bin/bash -c "egrep '*.dokku.me' $DOKKU_ROOT/${TEST_APP}/nginx.conf | wc -l"
+  assert_output "0"
 }
 
 @test "(nginx-vhosts) nginx:build-config (with SSL CN mismatch)" {

--- a/tests/unit/test_helper.bash
+++ b/tests/unit/test_helper.bash
@@ -89,7 +89,8 @@ create_app() {
 }
 
 destroy_app() {
-  RC="$1"; RC=${RC:=0}
+  local RC="$1"; local RC=${RC:=0}
+  local TEST_APP="$2"; local TEST_APP=${TEST_APP:=my-cool-guy-test-app}
   echo $TEST_APP | dokku apps:destroy $TEST_APP
   return $RC
 }


### PR DESCRIPTION
Filtering out the literal strings that start with `*.` seemed to be the simplest fix here.

@lmars @josegonzalez @vincentfretin 