### PR TITLE
Fixed bug with client commands taking verb, appname, and also arguments.

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -102,6 +102,11 @@ if [[ ! -z $DOKKU_HOST ]]; then
       if [[ ! "$1" =~ --* ]]; then
         verb=$1
         shift
+        
+        if [[ "$1" == "$appname" ]]; then
+          shift
+        fi
+        
         args="$*"
       else
         long_args="--"


### PR DESCRIPTION
When parsing args when handling verbs, appname can be included as an argument causing bugs with commands that accept a verb, appname, and also arguments.