### PR TITLE
[Fixes #1158] Split nginx logs by $APP

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -1,6 +1,6 @@
 # Nginx
 
-Dokku uses nginx as it's server for routing requests to specific applications.
+Dokku uses nginx as it's server for routing requests to specific applications. By default, access and error logs are written for each app to `/var/log/nginx/${APP}-access.log` and `/var/log/nginx/${APP}-error.log` respectively
 
 ## TLS/SPDY support
 
@@ -56,6 +56,8 @@ server {
   listen      [::]:80;
   listen      80;
   server_name $NOSSL_SERVER_NAME;
+  access_log  /var/log/nginx/${APP}-access.log;
+  error_log   /var/log/nginx/${APP}-error.log;
 
   # set a custom header for requests
   add_header X-Served-By www-ec2-01;

--- a/plugins/nginx-vhosts/templates/nginx.conf.template
+++ b/plugins/nginx-vhosts/templates/nginx.conf.template
@@ -2,6 +2,9 @@ server {
   listen      [::]:80;
   listen      80;
   server_name $NOSSL_SERVER_NAME;
+  access_log  /var/log/nginx/${APP}-access.log;
+  error_log   /var/log/nginx/${APP}-error.log;
+
   location    / {
     proxy_pass  http://$APP;
     proxy_http_version 1.1;

--- a/tests/unit/nginx-vhosts.bats
+++ b/tests/unit/nginx-vhosts.bats
@@ -53,12 +53,30 @@ assert_http_success() {
   assert_output "200"
 }
 
+assert_access_log() {
+  local prefix=$1
+  run [ -a /var/log/nginx/$prefix-access.log ]
+  assert_success
+}
+
+assert_error_log() {
+  local prefix=$1
+  run [ -a /var/log/nginx/$prefix-error.log ]
+  assert_success
+}
+
 @test "(nginx-vhosts) nginx (no server tokens)" {
   deploy_app
   run /bin/bash -c "curl -s -D - $(dokku url $TEST_APP) -o /dev/null | egrep '^Server' | egrep '[0-9]+'"
   echo "output: "$output
   echo "status: "$status
   assert_failure
+}
+
+@test "(nginx-vhosts) logging" {
+    deploy_app
+    assert_access_log ${TEST_APP}
+    assert_error_log ${TEST_APP}
 }
 
 @test "(nginx-vhosts) nginx:build-config (wildcard SSL)" {


### PR DESCRIPTION
 * nginx access logs to `/var/log/nginx/${APP}-access.log`
 * nginx error logs to `/var/log/nginx/${APP}-error.log`