### PR TITLE
Fix broken ssl wildcard redirect

### DIFF
--- a/plugins/nginx-vhosts/templates/nginx.ssl.conf.template
+++ b/plugins/nginx-vhosts/templates/nginx.ssl.conf.template
@@ -2,7 +2,7 @@ server {
   listen      [::]:80;
   listen      80;
   server_name $NOSSL_SERVER_NAME;
-  return 301 https://$SSL_SERVER_NAME\$request_uri;
+  return 301 https://\$host\$request_uri;
 }
 
 server {


### PR DESCRIPTION
Example Actual:
http://example.com  >  https://example.com  (works as it should)
http://test.example.com  >  https://\*.example.com  (BROKEN)
http://api.example.com  >  https://\*.example.com  (BROKEN)
http://app.example.com  >  https://\*.example.com  (BROKEN)
( https://*.example.com may appear as https://%2A.example.com depending on browser)

Example Expected:
http://example.com  >  https://example.com  (works as it should)
http://test.example.com  >  https://test.example.com  (Expected)
http://api.example.com  >  https://api.example.com  (Expected)
http://app.example.com  >  https://app.example.com  (Expected)

nginx redirects to https://\*.example.com/ which is a bogus url due to the $SSL_SERVER_NAME in the nginx template
Use nginx variable $host to do proper redirect