### PR TITLE
adding checks for curl and sudo.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -43,11 +43,14 @@ dokku_install_package() {
   curl -sSL https://get.docker.io/gpg | apt-key add -
   curl -sSL https://packagecloud.io/gpg.key | apt-key add -
 
+  sudo apt-get update > /dev/null
+  sudo apt-get install -qq -y apt-transport-https
+  
   echo "deb http://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
   echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ trusty main" > /etc/apt/sources.list.d/dokku.list
 
   sudo apt-get update > /dev/null
-  sudo apt-get install -qq -y "linux-image-extra-$(uname -r)" apt-transport-https
+  sudo apt-get install -qq -y "linux-image-extra-$(uname -r)"
 
   if [[ -n $DOKKU_CHECKOUT ]]; then
     sudo apt-get install -qq -y dokku=$DOKKU_CHECKOUT

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -14,6 +14,14 @@ if ! command -v apt-get &>/dev/null; then
   exit 1
 fi
 
+for CMD in curl sudo
+do
+  if ! command -v ${CMD} &>/dev/null; then
+    echo "Error: ${CMD} not found." >&2
+    exit 1
+  fi
+done
+
 apt-get update
 which curl > /dev/null || apt-get install -qq -y curl
 [[ $(lsb_release -sr) == "12.04" ]] && apt-get install -qq -y python-software-properties


### PR DESCRIPTION
Hi,

I just tried installing dokku using Debian Jessie i386.

bootstrap.sh failed because curl and sudo aren't part of the default installation.

I've added a check for them.  Can you pull this in?

Thanks,
Jason