### PR TITLE
Use --no-cache when building Dockerfile

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -41,7 +41,7 @@ case "$1" in
         # buildstep pluginhooks don't necessarily make sense for dockerfiles. call the new breed!!!
         pluginhook pre-build-dockerfile "$APP"
 
-        docker build -t "$IMAGE" .
+        docker build --no-cache -t "$IMAGE" .
 
         pluginhook post-build-dockerfile "$APP"
         ;;


### PR DESCRIPTION
Since `docker build` is only invoked when actually building a new image
from a Dockerfile, using `--no-cache` allows to have an updated image
even if the Dockerfile hasn't changed.
This works well with Dockerfiles using `git` or packages referencing
latest versions instead of "static" ones.