### PR TITLE
allow passing of docker build options and document dockerfile deployment. closes #1231

### DIFF
--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -56,7 +56,7 @@ Deployment of `Dockerfile` repos is supported as of v0.3.15. Simply place a Dock
 
 By default, we will extract the first `EXPOSE` port and tell nginx to proxy your app to that port. Alternatively, you can set `$DOCKERFILE_PORT` in your app's dokku configuration.
 
-You can also pass any `docker build` options to `docker`, by setting `$DOKKU_DOCKER_BUILD_OPTS`. Lastly, control of docker's image layer cache when deploying Dockerfiles with dokku can be had specifically by setting `$DOKKU_DOCKERFILE_CACHE_BUILD` to `true` or `false`.
+Setting `$DOKKU_DOCKERFILE_CACHE_BUILD` to `true` or `false` will enable or disable docker's image layer cache. Lastly, for more granular build control, you may also pass any `docker build` option to `docker`, by setting `$DOKKU_DOCKER_BUILD_OPTS`.
 
 ## Default vhost
 

--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -50,6 +50,14 @@ ssh -T git@github.com
 
 If buildpack detection isn't working well for you or you want to specify a custom buildpack for one repository you can create & commit a file in the root of your git repository named `.env` containing `export BUILDPACK_URL=<repository>` before pushing. This will tell buildstep to fetch the specified buildpack and use it instead of relying on the built-in buildpacks & their detection methods.
 
+## Dockerfile deployment
+
+Deployment of `Dockerfile` repos is supported as of v0.3.15. Simply place a Dockerfile in the root of your repo and push to dokku. If you are converting from a heroku/dokku buildpack deployment, ensure you are not setting `$BUILDPACK_URL` or including a `.buildpacks` file in the root of your repo.
+
+By default, we will extract the first `EXPOSE` port and tell nginx to proxy your app to that port. Alternatively, you can set `$DOCKERFILE_PORT` in your app's dokku configuration.
+
+You can also pass any `docker build` options to `docker`, by setting `$DOKKU_DOCKER_BUILD_OPTS`. Lastly, control of docker's image layer cache when deploying Dockerfiles with dokku can be had specifically by setting `$DOKKU_DOCKERFILE_CACHE_BUILD` to `true` or `false`.
+
 ## Default vhost
 
 You might notice the default vhost for Nginx will be one of the apps. If an app doesn't exist, it will use this vhost and it may be confusing for it to go to another app. You can create a default vhost using a configuration under `sites-enabled`. You just have to change one thing in the main nginx.conf:

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -7,6 +7,7 @@ case "$1" in
     APP="$2"; IMAGE="dokku/$APP"; IMAGE_SOURCE_TYPE="$3"; TMP_WORK_DIR="$4"
     CACHE_DIR="$DOKKU_ROOT/$APP/cache"
 
+    [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source "$DOKKU_ROOT/$APP/ENV"
     pushd "$TMP_WORK_DIR" &> /dev/null
 
     case "$IMAGE_SOURCE_TYPE" in
@@ -41,7 +42,8 @@ case "$1" in
         # buildstep pluginhooks don't necessarily make sense for dockerfiles. call the new breed!!!
         pluginhook pre-build-dockerfile "$APP"
 
-        docker build --no-cache -t "$IMAGE" .
+        [[ "$DOKKU_DOCKERFILE_CACHE_BUILD" == "false" ]] && DOKKU_DOCKER_BUILD_OPTS="$DOKKU_DOCKER_BUILD_OPTS --no-cache"
+        docker build $DOKKU_DOCKER_BUILD_OPTS -t "$IMAGE" .
 
         pluginhook post-build-dockerfile "$APP"
         ;;


### PR DESCRIPTION
- documents Dockerfile deployments
- exposes `$DOKKU_DOCKERFILE_CACHE_BUILD` for specific control of `--no-cache` on `docker build`
- exposes `$DOKKU_DOCKER_BUILD_OPTS` for injection of any `docker build` option
- sources `$DOKKU_ROOT/$APP/ENV` on `dokku build`