### PR TITLE
Support config variables containing `\n`

### DIFF
--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -38,7 +38,7 @@ config_styled_hash () {
 
 config_write() {
   ENV_TEMP="$1"
-  echo -e "$ENV_TEMP" | sed '/^$/d' | sort > $ENV_FILE_TEMP
+  echo "$ENV_TEMP" | sed '/^$/d' | sort > $ENV_FILE_TEMP
   if ! cmp -s $ENV_FILE $ENV_FILE_TEMP; then
     cp -f $ENV_FILE_TEMP $ENV_FILE
     chmod 600 $ENV_FILE
@@ -138,7 +138,8 @@ case "$1" in
       if [[ $KEY =~ [a-zA-Z_][a-zA-Z0-9_]* ]]; then
         RESTART_APP=true
         ENV_TEMP=$(echo "${ENV_TEMP}" | sed "/^export $KEY=/ d")
-        ENV_TEMP="${ENV_TEMP}\nexport $KEY='$VALUE'"
+        ENV_TEMP="${ENV_TEMP}
+export $KEY='$VALUE'"
         ENV_ADD=$(echo -e "${ENV_ADD}" | sed "/^$KEY=/ d")
         ENV_ADD="${ENV_ADD}$
 ${var}"

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -137,7 +137,7 @@ case "$1" in
 
       if [[ $KEY =~ [a-zA-Z_][a-zA-Z0-9_]* ]]; then
         RESTART_APP=true
-        ENV_TEMP=$(echo -e "${ENV_TEMP}" | sed "/^export $KEY=/ d")
+        ENV_TEMP=$(echo "${ENV_TEMP}" | sed "/^export $KEY=/ d")
         ENV_TEMP="${ENV_TEMP}\nexport $KEY='$VALUE'"
         ENV_ADD=$(echo -e "${ENV_ADD}" | sed "/^$KEY=/ d")
         ENV_ADD="${ENV_ADD}$

--- a/tests/unit/config.bats
+++ b/tests/unit/config.bats
@@ -20,7 +20,7 @@ teardown() {
 }
 
 @test "(config) config:get" {
-  run ssh dokku@dokku.me config:set $TEST_APP test_var=true test_var2=\"hello world\"
+  run ssh dokku@dokku.me config:set $TEST_APP test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
   echo "output: "$output
   echo "status: "$status
   assert_success
@@ -28,6 +28,10 @@ teardown() {
   echo "output: "$output
   echo "status: "$status
   assert_output 'hello world'
+  run dokku config:get $TEST_APP test_var3
+  echo "output: "$output
+  echo "status: "$status
+  assert_output 'with\nnewline'
 }
 
 @test "(config) config:unset" {


### PR DESCRIPTION
Right now, the following command completely messes up an apps `ENV` config file:

```
dokku config:set app "TEST=c\\na\\nb"
```

With these changes, the config file will contain look like expected:

```
export TEST='a\n\nb\nc'
```