### PR TITLE
Allows to skip checks (all or default)

### DIFF
--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -129,6 +129,8 @@ Dokku will wait `DOKKU_WAIT_TO_RETIRE` seconds (default: `60`) before stopping t
 
 Dokku will retry the checks DOKKU_CHECKS_ATTEMPTS times until the checks are successful or DOKKU_CHECKS_ATTEMPTS is exceeded.  In the latter case, the deployment is considered failed. This can be overridden in the CHECKS file by setting ATTEMPTS=nn.
 
+Checks can be skipped entirely by setting `DOKKU_SKIP_ALL_CHECKS` to `true` either globally or per application. You can choose to skip only default checks by setting `DOKKU_SKIP_DEFAULT_CHECKS` to `true` either globally or per application.
+
 See [checks-examples.md](checks-examples.md) for examples and output.
 
 # Removing a deployed app

--- a/dokku
+++ b/dokku
@@ -70,6 +70,9 @@ case "$1" in
     DOKKU_SCALE_FILE="$DOKKU_ROOT/$APP/DOKKU_SCALE"
     oldids=$(get_container_ids $APP)
 
+    [[ -f "$DOKKU_ROOT/ENV" ]] && source $DOKKU_ROOT/ENV
+    [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source $DOKKU_ROOT/$APP/ENV
+
     while read line || [ -n "$line" ]
     do
       PROC_TYPE=${line%%=*}
@@ -111,10 +114,14 @@ case "$1" in
         }
 
         # run checks first, then post-deploy hooks, which switches Nginx traffic
-        trap kill_new INT TERM EXIT
-        dokku_log_info1 "Running pre-flight checks"
-        pluginhook check-deploy  $APP $id $PROC_TYPE $port $ipaddr
-        trap -        INT TERM EXIT
+        if [[ "$DOKKU_SKIP_ALL_CHECKS" = "true" ]]; then
+          dokku_log_info1 "Skipping pre-flight checks"
+        else
+          trap kill_new INT TERM EXIT
+          dokku_log_info1 "Running pre-flight checks"
+          pluginhook check-deploy  $APP $id $PROC_TYPE $port $ipaddr
+          trap -        INT TERM EXIT
+        fi
 
         # now using the new container
         [[ -n "$id" ]] && echo $id > "$DOKKU_CONTAINER_ID_FILE"

--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -79,6 +79,10 @@ cleanup() {
 trap cleanup EXIT
 
 if [[ ! -s "${TMPDIR}/CHECKS" ]] || [[ "$DOKKU_APP_CONTAINER_TYPE" != "web" ]]; then
+  if [[ "$DOKKU_SKIP_DEFAULT_CHECKS" = "true" ]]; then
+    dokku_log_verbose "Skipping default check..."
+    exit 0
+  fi
   dokku_log_verbose "For more efficient zero downtime deployments, create a file CHECKS."
   dokku_log_verbose "See http://progrium.viewdocs.io/dokku/checks-examples.md for examples"
   dokku_log_verbose "CHECKS file not found in container: Running simple container check..."


### PR DESCRIPTION
Setting `DOKKU_SKIP_ALL_CHECKS` globally or for a given app will skip
all checks.
Setting `DOKKU_SKIP_DEFAULT_CHECKS` globally or for a given app will skip
default checks only.