### PR TITLE
Require lxc-docker-1.6.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ ifndef CI
 ifdef DOCKER_VERSION
 	apt-get install -qq -y lxc-docker-${DOCKER_VERSION}
 else
-	apt-get install -qq -y lxc-docker
+	apt-get install -qq -y lxc-docker-1.6.2
 endif
 	sleep 2 # give docker a moment i guess
 endif

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.3.12
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, software-properties-common, lxc-docker (>= 1.4.0), gcc, python-software-properties, man-db, buildstep, sshcommand, pluginhook
+Depends: locales, git, make, curl, software-properties-common, lxc-docker (>= 1.4.0), lxc-docker (<= 1.6.2), gcc, python-software-properties, man-db, buildstep, sshcommand, pluginhook
 Pre-Depends: nginx, dnsutils, ruby, ruby-dev, rubygem-rack, rubygem-rack-protection, rubygem-sinatra, rubygem-tilt, apparmor, cgroup-lite
 Provides: dokku
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.3.12
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, software-properties-common, lxc-docker (>= 1.4.0), lxc-docker (<= 1.6.2), gcc, python-software-properties, man-db, buildstep, sshcommand, pluginhook
+Depends: locales, git, make, curl, software-properties-common, lxc-docker-1.6.2, gcc, python-software-properties, man-db, buildstep, sshcommand, pluginhook
 Pre-Depends: nginx, dnsutils, ruby, ruby-dev, rubygem-rack, rubygem-rack-protection, rubygem-sinatra, rubygem-tilt, apparmor, cgroup-lite
 Provides: dokku
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>


### PR DESCRIPTION
1.7.0 Has issues with `docker ps` output, breaking all plugins

[ci-skip]