### PR TITLE
don't background cleanup

### DIFF
--- a/dokku
+++ b/dokku
@@ -174,7 +174,7 @@ case "$1" in
   cleanup)
     # delete all non-running container
     # shellcheck disable=SC2046
-    docker rm $(docker ps -a -f 'status=exited' -q) &> /dev/null &
+    docker rm $(docker ps -a -f 'status=exited' -q) &> /dev/null || true
     # delete unused images
     # shellcheck disable=SC2046
     docker rmi $(docker images -f 'dangling=true' -q) &> /dev/null &


### PR DESCRIPTION
This should prevent this random event from happening in the future:
```
Counting objects: 10, done.
Delta compression using up to 32 threads.
Compressing objects: 100% (6/6), done.
Writing objects: 100% (10/10), 1.50 KiB | 0 bytes/s, done.
Total 10 (delta 0), reused 0 (delta 0)
remote: -----> Cleaning up...
remote: -----> Building test-java-32254 from buildstep...
remote: time="2015-07-06T03:40:34Z" level="fatal" msg="Error response from daemon: No such container: f516ef28a768b1955144a3c3f866e49963284372e2aa90c05371882306a322b9" 
To dokku@dokku.me:test-java-32254
 ! [remote rejected] master -> master (pre-receive hook declined)
```

I've been running this in production for a few months now and no longer experience the `no such container` error during deploys.