### PR TITLE
initial pass at config plugin arguments refactor

### DIFF
--- a/dokku
+++ b/dokku
@@ -208,10 +208,10 @@ case "$1" in
     echo "Options:"
 
     cat<<EOF | pluginhook commands help | sort
-    help                                            Print the list of commands
-    plugins                                         Print active plugins
-    plugins-install                                 Install active plugins
-    plugins-update                                  Update active plugins
+    help                                                       Print the list of commands
+    plugins                                                    Print active plugins
+    plugins-install                                            Install active plugins
+    plugins-update                                             Update active plugins
 EOF
     ;;
 

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -216,12 +216,12 @@ case "$1" in
 
   help)
     cat && cat<<EOF
-    ls                                              Pretty listing of deployed applications and containers
-    logs <app> [-t]                                 Show the last logs for an application (-t follows)
-    run <app> <cmd>                                 Run a command in the environment of an application
-    url <app>                                       Show the first URL for an application (compatibility)
-    urls <app>                                      Show all URLs for an application
-    version                                         Print dokku's version
+    ls                                                         Pretty listing of deployed applications and containers
+    logs <app> [-t]                                            Show the last logs for an application (-t follows)
+    run <app> <cmd>                                            Run a command in the environment of an application
+    url <app>                                                  Show the first URL for an application (compatibility)
+    urls <app>                                                 Show all URLs for an application
+    version                                                    Print dokku's version
 EOF
     ;;
 

--- a/plugins/20_events/commands
+++ b/plugins/20_events/commands
@@ -40,10 +40,10 @@ case "$1" in
 
   help | events:help)
     cat && cat<<EOF
-    events [-t]                                     Show the last events (-t follows)
-    events:list                                     List logged events
-    events:on                                       Enable events logger
-    events:off                                      Disable events logger
+    events [-t]                                                Show the last events (-t follows)
+    events:list                                                List logged events
+    events:on                                                  Enable events logger
+    events:off                                                 Disable events logger
 EOF
     ;;
 

--- a/plugins/apps/commands
+++ b/plugins/apps/commands
@@ -55,9 +55,9 @@ case "$1" in
 
   help | apps:help)
     cat && cat<<EOF
-    apps                                            List your apps
-    apps:create <app>                               Create a new app
-    apps:destroy <app>                              Permanently destroy an app
+    apps                                                       List your apps
+    apps:create <app>                                          Create a new app
+    apps:destroy <app>                                         Permanently destroy an app
 EOF
     ;;
 

--- a/plugins/backup/commands
+++ b/plugins/backup/commands
@@ -87,8 +87,8 @@ case "$1" in
 
   help | backup:help)
     cat && cat<<EOF
-    backup:export [file]                            Export dokku configuration files
-    backup:import [file]                            Import dokku configuration files
+    backup:export [file]                                       Export dokku configuration files
+    backup:import [file]                                       Import dokku configuration files
 EOF
     ;;
 

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -2,8 +2,8 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$(dirname $0)/../common/functions"
 
-ENV_FILE="$DOKKU_ROOT/$2/ENV"
-ENV_FILE_TEMP="$DOKKU_ROOT/$2/ENV.tmp"
+DOKKU_CONFIG_RESTART=${DOKKU_CONFIG_RESTART:=true}
+
 config_create () {
   [ -f $ENV_FILE ] || {
     touch $ENV_FILE
@@ -38,6 +38,8 @@ config_styled_hash () {
 
 config_write() {
   ENV_TEMP="$1"
+  ENV_FILE_TEMP="${ENV_FILE}.tmp"
+
   echo "$ENV_TEMP" | sed '/^$/d' | sort > $ENV_FILE_TEMP
   if ! cmp -s $ENV_FILE $ENV_FILE_TEMP; then
     cp -f $ENV_FILE_TEMP $ENV_FILE
@@ -46,14 +48,36 @@ config_write() {
   rm -f $ENV_FILE_TEMP
 }
 
+parse_config_args() {
+  case "$2" in
+    --global)
+      ENV_FILE="$DOKKU_ROOT/ENV"
+      DOKKU_CONFIG_TYPE="global"
+      DOKKU_CONFIG_RESTART=false
+      ;;
+    --no-restart)
+      ARGS=("$@") && shift 2
+      DOKKU_CONFIG_RESTART=false dokku ${ARGS[0]} "$@"
+      exit 0
+      ;;
+    *)
+      ENV_FILE="$DOKKU_ROOT/$2/ENV"
+      DOKKU_CONFIG_TYPE="app"
+
+      [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
+      verify_app_name "$2"
+      APP="$2"
+      ;;
+    esac
+}
+
 case "$1" in
   config)
-    [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    verify_app_name "$2"
-    APP="$2"
-
+    parse_config_args "$@"
     config_create
-    [[ ! -s $ENV_FILE ]] && echo "$APP has no config vars" && exit 1
+
+    [[ "$APP" ]] && DOKKU_CONFIG_TYPE=$APP
+    [[ ! -s $ENV_FILE ]] && echo "no config vars for $DOKKU_CONFIG_TYPE" && exit 1
 
     VARS=$(grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" $ENV_FILE | cut -d" " -f2-)
 
@@ -64,14 +88,13 @@ case "$1" in
       fi
     done
 
-    dokku_log_info2_quiet "$APP config vars"
+
+    dokku_log_info2_quiet "$DOKKU_CONFIG_TYPE config vars"
     config_styled_hash "$VARS"
     ;;
 
   config:get)
-    [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    verify_app_name "$2"
-    APP="$2"
+    parse_config_args "$@"
 
     if [[ -z $3 ]]; then
       echo "Usage: dokku config:get APP KEY"
@@ -90,26 +113,7 @@ case "$1" in
     ;;
 
   config:set)
-    [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    verify_app_name "$2"
-    APP="$2"
-
-    if [[ -z "${*:3}" ]]; then
-      echo "Usage: dokku config:set APP KEY1=VALUE1 [KEY2=VALUE2 ...]"
-      echo "Must specify KEY and VALUE to set."
-      exit 1
-    fi
-
-    shift 2
-    dokku config:set-norestart $APP "$@"
-    dokku_log_info1 "Restarting app $APP"
-    dokku ps:restart $APP
-   ;;
-
-  config:set-norestart)
-    [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    verify_app_name "$2"
-    APP="$2"
+    parse_config_args "$@"
 
     if [[ -z "${*:3}" ]]; then
       echo "Usage: dokku config:set APP KEY1=VALUE1 [KEY2=VALUE2 ...]"
@@ -153,29 +157,15 @@ ${var}"
 
       config_write "$ENV_TEMP"
     fi
+
+    if [[ "$DOKKU_CONFIG_RESTART" == "true" ]]; then
+      dokku_log_info1 "Restarting app $APP"
+      dokku ps:restart $APP
+    fi
     ;;
 
   config:unset)
-    [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    verify_app_name "$2"
-    APP="$2"
-
-    if [[ -z $3 ]]; then
-      echo "Usage: dokku config:unset APP KEY1 [KEY2 ...]"
-      echo "Must specify KEY to unset."
-      exit 1
-    fi
-
-    shift 2
-    dokku config:unset-norestart $APP "$@"
-    dokku_log_info1 "Restarting app $APP"
-    dokku ps:restart $APP
-  ;;
-
-  config:unset-norestart)
-    [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
-    verify_app_name "$2"
-    APP="$2"
+    parse_config_args "$@"
 
     if [[ -z $3 ]]; then
       echo "Usage: dokku config:unset APP KEY1 [KEY2 ...]"
@@ -193,14 +183,31 @@ ${var}"
 
       config_write "$ENV_TEMP"
     done
+
+    if [[ "$DOKKU_CONFIG_RESTART" == "true" ]]; then
+      dokku_log_info1 "Restarting app $APP"
+      dokku ps:restart $APP
+    fi
+    ;;
+
+  config:set-norestart)
+    dokku_log_info2 "$1 is deprecated as of v0.3.22"
+    shift 1
+    dokku config:set --no-restart "$@"
+    ;;
+
+  config:unset-norestart)
+    dokku_log_info2 "$1 is deprecated as of v0.3.22"
+    shift 1
+    dokku config:unset --no-restart "$@"
     ;;
 
   help | config:help)
     cat && cat<<EOF
-    config <app>                                    Display the config vars for an app
-    config:get <app> KEY                            Display a config value for an app
-    config:set <app> KEY1=VALUE1 [KEY2=VALUE2 ...]  Set one or more config vars
-    config:unset <app> KEY1 [KEY2 ...]              Unset one or more config vars
+    config (<app>|--global)                                    Display all global or app-specific config vars
+    config:get (<app>|--global) KEY                            Display a global or app-specific config value
+    config:set (<app>|--global) KEY1=VALUE1 [KEY2=VALUE2 ...]  Set one or more config vars
+    config:unset (<app>|--global) KEY1 [KEY2 ...]              Unset one or more config vars
 EOF
     ;;
 

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -2,8 +2,6 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$(dirname $0)/../common/functions"
 
-DOKKU_CONFIG_RESTART=${DOKKU_CONFIG_RESTART:=true}
-
 config_create () {
   [ -f $ENV_FILE ] || {
     touch $ENV_FILE
@@ -24,7 +22,7 @@ config_styled_hash () {
 
   while read -r word; do
     KEY=$(echo $word | cut -d"=" -f1)
-    VALUE=$(echo $word | cut -d"=" -f2- | sed -e "s/^'//" -e "s/'$//")
+    VALUE=$(echo $word | cut -d"=" -f2- | sed -e "s/^'//" -e "s/'$//" -e "s/\$$//g")
 
     num_zeros=$((${#longest} - ${#KEY}))
     zeros=" "
@@ -56,19 +54,26 @@ parse_config_args() {
       DOKKU_CONFIG_RESTART=false
       ;;
     --no-restart)
-      ARGS=("$@") && shift 2
-      DOKKU_CONFIG_RESTART=false dokku ${ARGS[0]} "$@"
-      exit 0
-      ;;
-    *)
-      ENV_FILE="$DOKKU_ROOT/$2/ENV"
+      APP="$3"
+      ENV_FILE="$DOKKU_ROOT/$APP/ENV"
+      DOKKU_CONFIG_RESTART=false
       DOKKU_CONFIG_TYPE="app"
+      set -- "${@:1:1}" "${@:3}"
+  esac
 
-      [[ -z $2 ]] && echo "Please specify an app to run the command on" && exit 1
+  APP=${APP:="$2"}
+  ENV_FILE=${ENV_FILE:="$DOKKU_ROOT/$APP/ENV"}
+  DOKKU_CONFIG_TYPE=${DOKKU_CONFIG_TYPE:="app"}
+  DOKKU_CONFIG_RESTART=${DOKKU_CONFIG_RESTART:=true}
+
+  if [[ "$DOKKU_CONFIG_TYPE" = "app" ]]; then
+    if [[ -z $APP ]]; then
+      echo "Please specify an app to run the command on" >&2 && exit 1
+    else
       verify_app_name "$2"
-      APP="$2"
-      ;;
-    esac
+    fi
+  fi
+  export APP ENV_FILE DOKKU_CONFIG_TYPE DOKKU_CONFIG_RESTART
 }
 
 case "$1" in
@@ -114,6 +119,7 @@ case "$1" in
 
   config:set)
     parse_config_args "$@"
+    [[ "$2" = "--no-restart" ]] && set -- "${@:1:1}" "${@:3}"
 
     if [[ -z "${*:3}" ]]; then
       echo "Usage: dokku config:set APP KEY1=VALUE1 [KEY2=VALUE2 ...]"
@@ -166,6 +172,7 @@ ${var}"
 
   config:unset)
     parse_config_args "$@"
+    [[ "$2" = "--no-restart" ]] && set -- "${@:1:1}" "${@:3}"
 
     if [[ -z $3 ]]; then
       echo "Usage: dokku config:unset APP KEY1 [KEY2 ...]"

--- a/plugins/docker-options/commands
+++ b/plugins/docker-options/commands
@@ -141,10 +141,10 @@ case "$1" in
   # Display usage help
   help)
     cat && cat<<EOF
-    docker-options <app>                            Display apps docker options for all phases
-    docker-options <app> <phase(s)>                 Display apps docker options for phase (comma seperated phase list)
-    docker-options:add <app> <phase(s)> OPTION      Add docker option to app for phase (comma seperated phase list)
-    docker-options:remove <app> <phase(s)> OPTION   Remove docker option from app for phase (comma seperated phase list)
+    docker-options <app>                                       Display apps docker options for all phases
+    docker-options <app> <phase(s)>                            Display apps docker options for phase (comma seperated phase list)
+    docker-options:add <app> <phase(s)> OPTION                 Add docker option to app for phase (comma seperated phase list)
+    docker-options:remove <app> <phase(s)> OPTION              Remove docker option from app for phase (comma seperated phase list)
 EOF
   ;;
 

--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -133,10 +133,10 @@ case "$1" in
 
   help | domains:help)
     cat && cat<<EOF
-    domains <app>                                   List custom domains for app
-    domains:add <app> DOMAIN                        Add a custom domain to app
-    domains:clear <app>                             Clear all custom domains for app
-    domains:remove <app> DOMAIN                     Remove a custom domain from app
+    domains <app>                                              List custom domains for app
+    domains:add <app> DOMAIN                                   Add a custom domain to app
+    domains:clear <app>                                        Clear all custom domains for app
+    domains:remove <app> DOMAIN                                Remove a custom domain from app
 EOF
     ;;
 

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -167,8 +167,8 @@ EOF
 
   help | nginx:help)
     cat && cat<<EOF
-    nginx:import-ssl <app>                          Imports a tarball from stdin; should contain server.crt and server.key
-    nginx:build-config <app>                        (Re)builds nginx config for given app
+    nginx:import-ssl <app>                                     Imports a tarball from stdin; should contain server.crt and server.key
+    nginx:build-config <app>                                   (Re)builds nginx config for given app
 EOF
     ;;
 

--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -105,14 +105,14 @@ case "$1" in
 
   help | ps:help)
     cat && cat<<EOF
-    ps <app>                                        List processes running in app container(s)
-    ps:scale <app> <proc>=<count> [<proc>=<count>]  Set how many processes of a given process to run
-    ps:start <app>                                  Start app container(s)
-    ps:stop <app>                                   Stop app container(s)
-    ps:rebuild <app>                                Rebuild an app
-    ps:rebuildall                                   Rebuild all apps
-    ps:restart <app>                                Restart app container(s)
-    ps:restartall                                   Restart all deployed app containers
+    ps <app>                                                   List processes running in app container(s)
+    ps:scale <app> <proc>=<count> [<proc>=<count>]             Set how many processes of a given process to run
+    ps:start <app>                                             Start app container(s)
+    ps:stop <app>                                              Stop app container(s)
+    ps:rebuild <app>                                           Rebuild an app
+    ps:rebuildall                                              Rebuild all apps
+    ps:restart <app>                                           Restart app container(s)
+    ps:restartall                                              Restart all deployed app containers
 EOF
     ;;
 

--- a/plugins/shell/commands
+++ b/plugins/shell/commands
@@ -48,7 +48,7 @@ case "$1" in
 
   help | shell:help)
     cat && cat<<EOF
-    shell                                           Spawn dokku shell
+    shell                                                      Spawn dokku shell
 EOF
     ;;
 

--- a/tests/unit/config.bats
+++ b/tests/unit/config.bats
@@ -3,13 +3,55 @@
 load test_helper
 
 setup() {
+  [[ -f $DOKKU_ROOT/ENV ]] && mv -f $DOKKU_ROOT/ENV $DOKKU_ROOT/ENV.bak
   sudo -H -u dokku /bin/bash -c "echo 'export global_test=true' > $DOKKU_ROOT/ENV"
   create_app
 }
 
 teardown() {
   destroy_app
-  rm -f "$DOKKU_ROOT/ENV"
+  [[ -f $DOKKU_ROOT/ENV.bak ]] && mv -f $DOKKU_ROOT/ENV.bak $DOKKU_ROOT/ENV
+}
+
+@test "(config) config:set --global" {
+  run ssh dokku@dokku.me config:set --global test_var=true test_var2=\"hello world\"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+}
+
+@test "(config) config:get --global" {
+  run ssh dokku@dokku.me config:set --global test_var=true test_var2=\"hello world\" test_var3=\"with\\nnewline\"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  run dokku config:get --global test_var2
+  echo "output: "$output
+  echo "status: "$status
+  assert_output 'hello world'
+  run dokku config:get --global test_var3
+  echo "output: "$output
+  echo "status: "$status
+  assert_output 'with\nnewline'
+}
+
+@test "(config) config:unset --global" {
+  run ssh dokku@dokku.me config:set --global test_var=true test_var2=\"hello world\"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  run dokku config:get --global test_var
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  run dokku config:unset --global test_var
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  run dokku config:get --global test_var
+  echo "output: "$output
+  echo "status: "$status
+  assert_output ""
 }
 
 @test "(config) config:set" {


### PR DESCRIPTION
- adds `--global` for managing `$DOKKU_ROOT/ENV`
- adds `[config:set|config:unset] --no-restart`
- deprecates `config:set-norestart` and `config:unset-norestart`

```
root@dokku:~/dokku# dokku config --global
=====> global config vars
CURL_CONNECT_TIMEOUT: 5
CURL_TIMEOUT:         30
```

```
root@dokku:~/dokku# dokku config:set --no-restart node-js-app testing=true
-----> Setting config vars
       testing: true
```