### PR TITLE
Fix check-deploy skipping the root path

### DIFF
--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -138,7 +138,7 @@ do
     [[ -z "$CHECK_URL" || "$CHECK_URL" =~ ^\# ]] && continue
     # Ignore if it's not a URL in a supported format
     # shellcheck disable=SC1001
-    ! [[ "$CHECK_URL" =~ ^(http(s)?:)?\/.+ ]] && continue
+    ! [[ "$CHECK_URL" =~ ^(http(s)?:)?\/.* ]] && continue
 
     if [[ "$CHECK_URL" =~ ^https?: ]] ; then
       URL_PROTOCOL=${CHECK_URL%:*}

--- a/tests.mk
+++ b/tests.mk
@@ -75,6 +75,10 @@ else
 	@$(QUIET) ./tests/ci/unit_test_runner.sh $$UNIT_TEST_BATCH
 endif
 
+deploy-test-checks-root:
+	@echo deploying checks-root app...
+	cd tests && ./test_deploy ./apps/checks-root dokku.me '' true
+
 deploy-test-clojure:
 	@echo deploying config app...
 	cd tests && ./test_deploy ./apps/clojure dokku.me
@@ -137,6 +141,7 @@ deploy-test-static:
 
 deploy-tests:
 	@echo running deploy tests...
+	@$(QUIET) $(MAKE) deploy-test-checks-root
 	@$(QUIET) $(MAKE) deploy-test-config
 	@$(QUIET) $(MAKE) deploy-test-clojure
 	@$(QUIET) $(MAKE) deploy-test-dockerfile

--- a/tests/apps/checks-root/CHECKS
+++ b/tests/apps/checks-root/CHECKS
@@ -1,0 +1,2 @@
+ATTEMPTS=2
+/

--- a/tests/apps/checks-root/index.js
+++ b/tests/apps/checks-root/index.js
@@ -1,0 +1,11 @@
+var express = require('express');
+var app = express();
+
+app.get('/', function(req, res) {
+  res.sendStatus(404);
+});
+
+var port = process.env.PORT || 5000;
+app.listen(port, function() {
+  console.log('Listening on port ' + port);
+});

--- a/tests/apps/checks-root/package.json
+++ b/tests/apps/checks-root/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "node-example",
+  "version": "0.0.1",
+  "dependencies": {
+    "express": "4.x"
+  },
+  "engines": {
+    "node": "0.12.x",
+    "npm": "2.x"
+  },
+  "scripts": {
+    "start": "node index.js"
+  }
+}

--- a/tests/test_deploy
+++ b/tests/test_deploy
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xeo pipefail
 
-SELF=$(which $0); APP="$1"; TARGET="$2"; FORWARDED_PORT="$3"
+SELF=$(which $0); APP="$1"; TARGET="$2"; FORWARDED_PORT="$3"; SHOULD_FAIL="$4"
 REMOTE="dokku@$TARGET"
 REPO="test-$(basename $APP)-$RANDOM"
 
@@ -11,6 +11,12 @@ destroy_app(){
 
 failed(){
   echo "************ $1 failed ************"
+  destroy_app
+  exit 1
+}
+
+succeeded(){
+  echo "************ $1 succeeded but should have failed ************"
   destroy_app
   exit 1
 }
@@ -28,9 +34,19 @@ git add .
 
 [[ -x pre-commit ]] && ./pre-commit $REMOTE $REPO
 git commit -m 'initial commit'
-git push target master || failed git-push
+if [[ "$SHOULD_FAIL" == true ]]; then
+  git push target master && succeeded git-push
+else
+  git push target master || failed git-push
+fi
 if [[ -x post-deploy ]]; then
   ./post-deploy $REMOTE $REPO || failed post-deploy
+fi
+
+if [[ "$SHOULD_FAIL" == true ]]; then
+  echo "-----> Deploy failed (as it should have)!"
+  destroy_app
+  exit 0
 fi
 
 URL=$(dokku url $REPO)$FORWARDED_PORT


### PR DESCRIPTION
I noticed that `check-deploy` was no longer correctly checking the root path, `/`, due to [6eefcbb](https://github.com/progrium/dokku/commit/6eefcbb87c1d13d3ff0623a7fd58d37261112d71). This commit fixes this by not requiring any characters after the slash.