### PR TITLE
Set X-Forwarded-Proto header if TLS is enabled when running checks

### DIFF
--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -125,6 +125,11 @@ do
   # --location   Follow redirects
   CURL_OPTIONS="-q --compressed --fail --location --max-time $TIMEOUT"
 
+  # Set X-Forwarded-Proto header if TLS is enabled.
+  SSL="$DOKKU_ROOT/$APP/tls"; WILDCARD_SSL="$DOKKU_ROOT/tls"
+  if [[ -e "$SSL/server.crt" && -e "$SSL/server.key" ]] || [[ -e "$WILDCARD_SSL/server.crt" && -e "$WILDCARD_SSL/server.key" ]]; then
+    CURL_OPTIONS+=" -H X-Forwarded-Proto:https"
+  fi
 
   exec < "$FILENAME"
   while read CHECK_URL EXPECTED ; do


### PR DESCRIPTION
If I have an app which only responds to HTTPS requests (or redirects non-secure requests to HTTPS) any checks defined in the `CHECKS` file will fail. This isn’t a problem for “real requests” as nginx sets the `X-Forwarded-Proto` header accordingly.

I therefore suggest setting the `X-Forwarded-Proto` header to `https` when running checks against a TLS-enabled app.