### PR TITLE
Add reset mtime plugin list

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -83,6 +83,8 @@ Note: The following plugins have been supplied by our community and may not have
 [Benjamin-Dobell]: https://github.com/Benjamin-Dobell
 [jagandecapri]: https://github.com/jagandecapri
 [mixxorz]: https://github.com/mixxorz
+[Maciej Łebkowski]: https://github.com/mlebkowski
+[abossard]: https://github.com/dudagroup
 
 ### Datastores
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -82,6 +82,7 @@ Note: The following plugins have been supplied by our community and may not have
 [ribot]: https://github.com/ribot
 [Benjamin-Dobell]: https://github.com/Benjamin-Dobell
 [jagandecapri]: https://github.com/jagandecapri
+[mixxorz]: https://github.com/mixxorz
 
 ### Datastores
 
@@ -196,6 +197,7 @@ Note: The following plugins have been supplied by our community and may not have
 | [Node](https://github.com/pnegahdar/dokku-node)                                                   | [pnegahdar][]         |                       |
 | [Node](https://github.com/ademuk/dokku-nodejs)                                                    | [ademuk][]            |                       |
 | [Rails logs](https://github.com/Flink/dokku-rails-logs)                                           | [Flink][]             |                       |
+| [Reset mtime](https://github.com/mixxorz/dokku-docker-reset-mtime)                                | [mixxorz][]           | 0.3.15+, Dockerfile support |
 | [Slack Notifications](https://github.com/ribot/dokku-slack)                                       | [ribot][]             |                       |
 | [User ACL](https://github.com/mlebkowski/dokku-acl)                                               | [Maciej Łebkowski][]  |                       |
 | [Webhooks](https://github.com/nickstenning/dokku-webhooks)                                        | [nickstenning][]      |                       |


### PR DESCRIPTION
I made a plugin that resets the mtime on your source files before they get built by `docker build`. 

Here's the relevant [Docker PR](https://github.com/docker/docker/pull/12031) the issue.

My solution is based off [this StackOverflow question](http://stackoverflow.com/questions/26531108/docker-add-cache-when-git-checkout-same-file/26612694#26612694).

P.S. I fixed some missing links with two authors. :smile: 