### PR TITLE
in nginx doc, mention where original templates are found by default.

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -94,6 +94,8 @@ A few tips for custom nginx templates:
 - Templated files will be validated via `nginx -t`.
 - Application environment variables can be used within your nginx configuration.
 
+After your changes a `dokku reploy myapp` will regenerate the `/home/dokku/myapp/nginx.conf` file which is then used.
+
 ## Customizing hostnames
 
 Applications typically have the following structure for their hostname:

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -94,7 +94,7 @@ A few tips for custom nginx templates:
 - Templated files will be validated via `nginx -t`.
 - Application environment variables can be used within your nginx configuration.
 
-After your changes a `dokku reploy myapp` will regenerate the `/home/dokku/myapp/nginx.conf` file which is then used.
+After your changes a `dokku deploy myapp` will regenerate the `/home/dokku/myapp/nginx.conf` file which is then used.
 
 ## Customizing hostnames
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -56,7 +56,7 @@ This archive should is expanded via `tar xvf`. It should contain `server.crt` an
 
 > New as of 0.3.10
 
-Dokku currently templates out an nginx configuration that is included in the `nginx-vhosts` plugin. If you'd like to provide a custom template for your application, you should copy the existing template - ssl or non-ssl - into your `$DOKKU_ROOT/$APP` directory at the file `nginx.conf.template`.
+Dokku currently templates out an nginx configuration that is included in the `nginx-vhosts` plugin. If you'd like to provide a custom template for your application, you should copy the existing template - ssl or non-ssl - into your `$DOKKU_ROOT/$APP` directory at the file `nginx.conf.template`.  If you followed the default installation path, the original templates are found in `/var/lib/dokku/plugins/nginx-vhosts/templates/nginx{.ssl,}.conf.template` .
 
 For instance - assuming defaults - to customize the nginx template in use for the `myapp` application, create a file at `/home/dokku/myapp/nginx.conf.template` with the following contents:
 


### PR DESCRIPTION
As I would have liked to avoid the extra steps and search the default templates (the instruction just say to "copy them"), added reference to default path of these templates.

Also mention how to apply the changes. I do not know the simplest way, but i found `dokku deploy myapp` works well and fast.