### PR TITLE
use config:get for checks skipping variables

### DIFF
--- a/dokku
+++ b/dokku
@@ -73,9 +73,6 @@ case "$1" in
     DOKKU_SCALE_FILE="$DOKKU_ROOT/$APP/DOKKU_SCALE"
     oldids=$(get_container_ids $APP)
 
-    [[ -f "$DOKKU_ROOT/ENV" ]] && source $DOKKU_ROOT/ENV
-    [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source $DOKKU_ROOT/$APP/ENV
-
     while read line || [ -n "$line" ]
     do
       PROC_TYPE=${line%%=*}
@@ -119,6 +116,14 @@ case "$1" in
           trap - INT TERM EXIT
           kill -9 $$
         }
+
+        DOKKU_APP_SKIP_ALL_CHECKS=$(dokku config:get $APP DOKKU_SKIP_ALL_CHECKS || true)
+        DOKKU_APP_SKIP_DEFAULT_CHECKS=$(dokku config:get $APP DOKKU_SKIP_DEFAULT_CHECKS || true)
+        DOKKU_GLOBAL_SKIP_ALL_CHECKS=$(dokku config:get --global DOKKU_SKIP_ALL_CHECKS || true)
+        DOKKU_GLOBAL_SKIP_DEFAULT_CHECKS=$(dokku config:get --global DOKKU_SKIP_DEFAULT_CHECKS || true)
+
+        DOKKU_SKIP_ALL_CHECKS=${DOKKU_APP_SKIP_ALL_CHECKS:="$DOKKU_GLOBAL_SKIP_ALL_CHECKS"}
+        DOKKU_SKIP_DEFAULT_CHECKS=${DOKKU_APP_SKIP_DEFAULT_CHECKS:="$DOKKU_GLOBAL_SKIP_DEFAULT_CHECKS"}
 
         # run checks first, then post-deploy hooks, which switches Nginx traffic
         if [[ "$DOKKU_SKIP_ALL_CHECKS" = "true" ]]; then


### PR DESCRIPTION
this uses `config:get` to set `$DOKKU_SKIP_ALL_CHECKS` and `$DOKKU_SKIP_DEFAULT_CHECKS`