### PR TITLE
Spelling fix: 'comma seperated'=>'comma-separated'

### DIFF
--- a/docs/docker-options.md
+++ b/docs/docker-options.md
@@ -8,9 +8,9 @@ Usage
 $ dokku help
 ...
     docker-options <app>                               Display apps docker options for all phases
-    docker-options <app> <phase(s)>                    Display apps docker options for phase (comma seperated phase list)
-    docker-options:add <app> <phase(s)> OPTION         Add docker option to app for phase (comma seperated phase list)
-    docker-options:remove <app> <phase(s)> OPTION      Remove docker option from app for phase (comma seperated phase list)
+    docker-options <app> <phase(s)>                    Display apps docker options for phase (comma-separated phase list)
+    docker-options:add <app> <phase(s)> OPTION         Add docker option to app for phase (comma-separated phase list)
+    docker-options:remove <app> <phase(s)> OPTION      Remove docker option from app for phase (comma-separated phase list)
 ...
 ````
 

--- a/plugins/docker-options/commands
+++ b/plugins/docker-options/commands
@@ -142,9 +142,9 @@ case "$1" in
   help)
     cat && cat<<EOF
     docker-options <app>                                       Display apps docker options for all phases
-    docker-options <app> <phase(s)>                            Display apps docker options for phase (comma seperated phase list)
-    docker-options:add <app> <phase(s)> OPTION                 Add docker option to app for phase (comma seperated phase list)
-    docker-options:remove <app> <phase(s)> OPTION              Remove docker option from app for phase (comma seperated phase list)
+    docker-options <app> <phase(s)>                            Display apps docker options for phase (comma-separated phase list)
+    docker-options:add <app> <phase(s)> OPTION                 Add docker option to app for phase (comma-separated phase list)
+    docker-options:remove <app> <phase(s)> OPTION              Remove docker option from app for phase (comma-separated phase list)
 EOF
   ;;
 


### PR DESCRIPTION
Changed  "comma seperated" to "comma-separated" in `docker-options/commands` and related docs. 