### PR TITLE
In doc: mention alternative to nginx.conf templates: include-dir.

### DIFF
--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -102,14 +102,12 @@ The default nginx.conf- templates will include everything from your apps `nginx.
 
     include $DOKKU_ROOT/$APP/nginx.conf.d/*.conf;
 
-. That means you can put additional configuration in separate files, for example to limit the uploaded body size to 50 megabyte, do
+. That means you can put additional configuration in separate files, for example to limit the uploaded body size to 50 megabytes, do
 
     mkdir /home/dokku/myapp/nginx.conf.d/
     echo 'client_max_body_size 50M;' > /home/dokku/myapp/nginx.conf.d/upload.conf
     chown dokku:dokku /home/dokku/myapp/nginx.conf.d/upload.conf
     service nginx reload
-
-(taken from https://github.com/dokku-alt/dokku-alt/issues/195#issuecomment-75092205).
 
 ## Customizing hostnames
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -96,6 +96,21 @@ A few tips for custom nginx templates:
 
 After your changes a `dokku deploy myapp` will regenerate the `/home/dokku/myapp/nginx.conf` file which is then used.
 
+### Customizing via configuration files included by the default templates
+
+The default nginx.conf- templates will include everything from your apps `nginx.conf.d/` subdirectory in the main `server {}` block (see above):
+
+    include $DOKKU_ROOT/$APP/nginx.conf.d/*.conf;
+
+. That means you can put additional configuration in separate files, for example to limit the uploaded body size to 50 megabyte, do
+
+    mkdir /home/dokku/myapp/nginx.conf.d/
+    echo 'client_max_body_size 50M;' > /home/dokku/myapp/nginx.conf.d/upload.conf
+    chown dokku:dokku /home/dokku/myapp/nginx.conf.d/upload.conf
+    service nginx reload
+
+(taken from https://github.com/dokku-alt/dokku-alt/issues/195#issuecomment-75092205).
+
 ## Customizing hostnames
 
 Applications typically have the following structure for their hostname:


### PR DESCRIPTION
In the line of #1303 , mention that parts of nginx-configuration can also be put in `$APP/nginx.conf.d/` if default templates are used.

Reference to comment in other issue (does not look very nice in the documentation, can probably be removed).