### PR TITLE
[bugfix] in nginx.conf.template getting from /app directory

### DIFF
--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -50,7 +50,7 @@ case "$1" in
     fi
 
     DOKKU_APP_CIDS=($(get_app_container_ids $APP))
-    docker cp "${DOKKU_APP_CID[0]}:/app/nginx.conf.template" "$APP_NGINX_TEMPLATE" 2> /dev/null || true
+    docker cp "${DOKKU_APP_CIDS[0]}:/app/nginx.conf.template" "$DOKKU_ROOT/$APP/" 2> /dev/null || true
 
     [[ -f "$DOKKU_ROOT/ENV" ]] && source $DOKKU_ROOT/ENV
     [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source $DOKKU_ROOT/$APP/ENV


### PR DESCRIPTION
There is bugfix for ability to get 'nginx.conf.template' from original repository. The bug is small and fix is just syntax correction.