### PR TITLE
Add better error checking on nginx:import-ssl

### DIFF
--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -162,17 +162,17 @@ EOF
     cd $TEMP_DIR
     tar xvf - <&0
 
-    crt_count = $(ls -1 *.crt | wc -l)
-    if [[ $crt_count -lt 1 ]]; then
+    CRT_FILE_COUNT=$(ls -1 ./*.crt | wc -l)
+    if [[ $CRT_FILE_COUNT -lt 1 ]]; then
       echo "Tar archive is missing .crt file" && exit 1
-    elif [[ $crt_count -gt 1 ]]; then
+    elif [[ $CRT_FILE_COUNT -gt 1 ]]; then
       echo "Tar archive contains more than one .crt file" && exit 1
     fi
 
-    key_count = $(ls -1 *.key | wc -l)
-    if [[ $key_count -lt 1 ]]; then
+    KEY_FILE_COUNT=$(ls -1 ./*.key | wc -l)
+    if [[ $KEY_FILE_COUNT -lt 1 ]]; then
       echo "Tar archive is missing .key file" && exit 1
-    elif [[ $key_count -gt 1 ]]; then
+    elif [[ $KEY_FILE_COUNT -gt 1 ]]; then
       echo "Tar archive contains more than one .key file" && exit 1
     fi
 

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -161,12 +161,24 @@ EOF
     TEMP_DIR=$(mktemp -d)
     cd $TEMP_DIR
     tar xvf - <&0
-    [[ ! -f "$TEMP_DIR/server.crt" ]] && echo "Tar archive missing server.crt" && exit 1
-    [[ ! -f "$TEMP_DIR/server.key" ]] && echo "Tar archive missing server.key" && exit 1
+
+    crt_count = $(ls -1 *.crt | wc -l)
+    if [[ $crt_count -lt 1 ]]; then
+      echo "Tar archive is missing .crt file" && exit 1
+    elif [[ $crt_count -gt 1 ]]; then
+      echo "Tar archive contains more than one .crt file" && exit 1
+    fi
+
+    key_count = $(ls -1 *.key | wc -l)
+    if [[ $key_count -lt 1 ]]; then
+      echo "Tar archive is missing .key file" && exit 1
+    elif [[ $key_count -gt 1 ]]; then
+      echo "Tar archive contains more than one .key file" && exit 1
+    fi
 
     mkdir -p "$DOKKU_ROOT/$APP/tls"
-    mv "$TEMP_DIR/server.crt" "$DOKKU_ROOT/$APP/tls/server.crt"
-    mv "$TEMP_DIR/server.key" "$DOKKU_ROOT/$APP/tls/server.key"
+    mv "$TEMP_DIR/*.crt" "$DOKKU_ROOT/$APP/tls/server.crt"
+    mv "$TEMP_DIR/*.key" "$DOKKU_ROOT/$APP/tls/server.key"
     cd $DOKKU_ROOT
     rm -rf $TEMP_DIR
     dokku nginx:build-config $APP

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -162,23 +162,30 @@ EOF
     cd $TEMP_DIR
     tar xvf - <&0
 
-    CRT_FILE_COUNT=$(ls -1 ./*.crt | wc -l)
+    CRT_FILE_SEARCH=$(find . -type f -name "*.crt")
+    CRT_FILE_COUNT=$(printf "%s" "$CRT_FILE_SEARCH" | grep -c '^')
     if [[ $CRT_FILE_COUNT -lt 1 ]]; then
       echo "Tar archive is missing .crt file" && exit 1
     elif [[ $CRT_FILE_COUNT -gt 1 ]]; then
       echo "Tar archive contains more than one .crt file" && exit 1
+    else
+      CRT_FILE=$CRT_FILE_SEARCH
     fi
 
-    KEY_FILE_COUNT=$(ls -1 ./*.key | wc -l)
+    KEY_FILE_SEARCH=$(find . -type f -name "*.key")
+    KEY_FILE_COUNT=$(printf "%s" "$KEY_FILE_SEARCH" | grep -c '^')
     if [[ $KEY_FILE_COUNT -lt 1 ]]; then
       echo "Tar archive is missing .key file" && exit 1
     elif [[ $KEY_FILE_COUNT -gt 1 ]]; then
       echo "Tar archive contains more than one .key file" && exit 1
+    else
+      KEY_FILE=$KEY_FILE_SEARCH
     fi
 
+
     mkdir -p "$DOKKU_ROOT/$APP/tls"
-    mv "$TEMP_DIR/*.crt" "$DOKKU_ROOT/$APP/tls/server.crt"
-    mv "$TEMP_DIR/*.key" "$DOKKU_ROOT/$APP/tls/server.key"
+    mv "$CRT_FILE" "$DOKKU_ROOT/$APP/tls/server.crt"
+    mv "$KEY_FILE" "$DOKKU_ROOT/$APP/tls/server.key"
     cd $DOKKU_ROOT
     rm -rf $TEMP_DIR
     dokku nginx:build-config $APP


### PR DESCRIPTION
The script would only accept files named exactly `server.crt` and `server.key`. Some certificate authorities distribute these files with names according to the domain they apply to, so this approach on dokku's end is rather limited.

I added error handling that ensures there is only one `.crt` file and one `.key` file and then modified the `mv` command so it renames the files from whatever to `server.crt` and `server.key`.

An error case not handled by my addition (feel free to tack on!) is if the `tar`ed files have a path in front of them, for example `~/ssl/server.crt`. EDIT: This error case is now handled! Files will be found if they are extracted to a subdirectory.

Let me know if my code does not follow standards/best practices, this is my first time contributing to dokku and to a bash project! 😄