### PR TITLE
Allow stop/kill to continue in the event that it cannot stop or kill one of the old containers

### DIFF
--- a/dokku
+++ b/dokku
@@ -178,8 +178,12 @@ case "$1" in
         trap '' INT HUP
         sleep $WAIT
         for oldid in $oldids; do
-          docker stop $oldid &> /dev/null
-          docker kill $oldid &> /dev/null  # force a kill as docker seems to not send SIGKILL as the docs would indicate
+          # Attempt to stop, if that fails, then force a kill as docker seems
+          # to not send SIGKILL as the docs would indicate. If that fails, move
+          # on to the next.
+          docker stop $oldid \
+          || docker kill $oldid \
+          || :  # Always continue in case we have multiple to kill
         done
       ) & disown -a
       # Use trap since disown/nohup don't seem to keep child alive


### PR DESCRIPTION
In the event that we cannot stop a container, we should try to kill it, and if that then fails, we should continue to the next $oldid , otherwise one container not actually being there or not able to be stopped will prevent the rest from being cleaned up.

The way this is, if a container ever fails to stop, it will never kill it anyway, due to being executed with -e.
This fixes that as well with a simple or.

The bigger issue at hand here is that if you change your container process types around it doesn't really cleanup after itself, leaving CONTAINER.$type.$nid and PORT.$type.$nid files around, but I didn't get around to addressing that.