### PR TITLE
only run domains and nginx config if we have a port and ip

### DIFF
--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -3,12 +3,14 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$(dirname $0)/../common/functions"
 
 APP="$1"
-NO_VHOST=$(dokku config:get $APP NO_VHOST || true)
+if [[ -f "$DOKKU_ROOT/$APP/IP.web.1" ]] && [[ -f "$DOKKU_ROOT/$APP/PORT.web.1" ]]; then
+  NO_VHOST=$(dokku config:get $APP NO_VHOST || true)
 
-if [[ -n "$NO_VHOST" ]]; then
-  dokku_log_info1 "NO_VHOST config detected"
-elif [[ ! -f "$DOKKU_ROOT/$APP/VHOST" ]]; then
-  dokku domains:setup $APP
+  if [[ -n "$NO_VHOST" ]]; then
+    dokku_log_info1 "NO_VHOST config detected"
+  elif [[ ! -f "$DOKKU_ROOT/$APP/VHOST" ]]; then
+    dokku domains:setup $APP
+  fi
+
+  dokku nginx:build-config $APP
 fi
-
-dokku nginx:build-config $APP

--- a/tests.mk
+++ b/tests.mk
@@ -119,6 +119,10 @@ deploy-test-nodejs-express-noprocfile:
 	@echo deploying nodejs-express app with no Procfile...
 	cd tests && ./test_deploy ./apps/nodejs-express-noprocfile dokku.me
 
+deploy-test-nodejs-worker:
+	@echo deploying nodejs-worker app...
+	cd tests && ./test_deploy ./apps/nodejs-worker dokku.me
+
 deploy-test-php:
 	@echo deploying php app...
 	cd tests && ./test_deploy ./apps/php dokku.me
@@ -152,6 +156,7 @@ deploy-tests:
 	@$(QUIET) $(MAKE) deploy-test-multi
 	@$(QUIET) $(MAKE) deploy-test-nodejs-express
 	@$(QUIET) $(MAKE) deploy-test-nodejs-express-noprocfile
+	@$(QUIET) $(MAKE) deploy-test-nodejs-worker
 	@$(QUIET) $(MAKE) deploy-test-php
 	@$(QUIET) $(MAKE) deploy-test-python-flask
 	@$(QUIET) $(MAKE) deploy-test-scala

--- a/tests/apps/nodejs-worker/DOKKU_SCALE
+++ b/tests/apps/nodejs-worker/DOKKU_SCALE
@@ -1,0 +1,2 @@
+web=0
+worker=1

--- a/tests/apps/nodejs-worker/Procfile
+++ b/tests/apps/nodejs-worker/Procfile
@@ -1,0 +1,1 @@
+worker: node worker.js

--- a/tests/apps/nodejs-worker/check_deploy
+++ b/tests/apps/nodejs-worker/check_deploy
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+set -e; output="$(pgrep -f "node worker.js" | wc -l)"; echo "$output"; test "$output" == "1"

--- a/tests/apps/nodejs-worker/package.json
+++ b/tests/apps/nodejs-worker/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "node-example",
+  "version": "0.0.1",
+  "engines": {
+    "node": "0.10.x",
+    "npm": "2.7.x"
+  }
+}

--- a/tests/apps/nodejs-worker/worker.js
+++ b/tests/apps/nodejs-worker/worker.js
@@ -1,0 +1,6 @@
+function worker() {
+  console.log('sleeping for 60 seconds');
+  setTimeout(worker, 60 * 1000);
+}
+
+worker();


### PR DESCRIPTION
- only run domains:setup and nginx:build-conifg if IP.web.1 and PORT.web.1 files exist
- added test app that just contains a worker process

fixes #1355