### PR TITLE
support dockerfile images that don't include bash

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -134,7 +134,7 @@ verify_image() {
 is_image_buildstep_based() {
   # circleci can't support --rm as they run lxc in lxc
   [[ ! -f "/home/ubuntu/.circlerc" ]] && local DOCKER_ARGS="--rm"
-  docker run --entrypoint="/bin/bash" $DOCKER_ARGS "$@" -c "[[ -f /exec ]]"
+  docker run --entrypoint="/bin/sh" $DOCKER_ARGS "$@" -c "test -f /exec"
 }
 
 is_number() {

--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -12,7 +12,7 @@ case "$1" in
     ! (is_deployed $APP) && echo "App $APP has not been deployed" && exit 0
 
     for CID in $CONTAINER_IDS; do
-      docker exec -ti "$CID" /bin/bash -c "ps auxwww"
+      docker exec -ti "$CID" /bin/sh -c "ps auxwww"
     done
   ;;
 


### PR DESCRIPTION
use /bin/sh instead of /bin/bash in
- `is_image_buildstep_based()`
- `dokku ps`

fixes #1364 