### PR TITLE
Do no longer force-install a default nginx.conf

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -22,7 +22,6 @@ ssl_session_cache shared:SSL:20m;
 ssl_session_timeout 10m;
 
 ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
-ssl_protocols TLSv1.2 TLSv1.1 TLSv1;
 ssl_prefer_server_ciphers on;
 
 # ssl_certificate $DOKKU_ROOT/tls/server.crt;

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -18,6 +18,8 @@ if [[ ! -f /etc/nginx/conf.d/dokku.conf ]]; then
   cat<<EOF > /etc/nginx/conf.d/dokku.conf
 include $DOKKU_ROOT/*/nginx.conf;
 
+server_tokens off;
+
 ssl_session_cache shared:SSL:20m;
 ssl_session_timeout 10m;
 

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -22,7 +22,6 @@ ssl_session_cache shared:SSL:20m;
 ssl_session_timeout 10m;
 
 ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
-ssl_prefer_server_ciphers on;
 
 # ssl_certificate $DOKKU_ROOT/tls/server.crt;
 # ssl_certificate_key $DOKKU_ROOT/tls/server.key;

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -30,37 +30,6 @@ ssl_prefer_server_ciphers on;
 EOF
 fi
 
-cat<<EOF > /etc/nginx/nginx.conf
-user www-data;
-worker_processes auto;
-pid /run/nginx.pid;
-
-events {
-  worker_connections 768;
-}
-
-http {
-  server_tokens off;
-  sendfile on;
-  tcp_nopush on;
-  tcp_nodelay on;
-  keepalive_timeout 65;
-  types_hash_max_size 2048;
-
-  include /etc/nginx/mime.types;
-  default_type application/octet-stream;
-  access_log /var/log/nginx/access.log;
-  error_log /var/log/nginx/error.log;
-
-  gzip on;
-  gzip_disable "msie6";
-
-  include /etc/nginx/conf.d/*.conf;
-  include /etc/nginx/sites-enabled/*;
-}
-
-EOF
-
 echo 'server_names_hash_bucket_size 512;' >| /etc/nginx/conf.d/server_names_hash_bucket_size.conf
 
 case "$DOKKU_DISTRO" in


### PR DESCRIPTION
As far as I can tell, a default `nginx.conf` does no longer need to be force-installed. Let me know if I forgot something.