### PR TITLE
Removed uses of `sudo` from `bootstrap.sh`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,13 +38,13 @@ dokku_install_package() {
   echo "deb http://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
   echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ trusty main" > /etc/apt/sources.list.d/dokku.list
 
-  sudo apt-get update > /dev/null
-  sudo apt-get install -qq -y "linux-image-extra-$(uname -r)" apt-transport-https
+  apt-get update > /dev/null
+  apt-get install -qq -y "linux-image-extra-$(uname -r)" apt-transport-https
 
   if [[ -n $DOKKU_CHECKOUT ]]; then
-    sudo apt-get install -qq -y dokku=$DOKKU_CHECKOUT
+    apt-get install -qq -y dokku=$DOKKU_CHECKOUT
   else
-    sudo apt-get install -qq -y dokku
+    apt-get install -qq -y dokku
   fi
 }
 


### PR DESCRIPTION
`apt` package installs in `bootstrap.sh` fails to acknowledge the `DEBIAN_FRONTEND=noninteractive` envvar because of the use of `sudo`, because the -E flag is not set. However, the script also assumes that it will be run with `sudo` in the first place, so it shouldn't be needed. In the event that it is needed, it can be run with -E instead.