### PR TITLE
Remove `dokku plugins-install` from postinst hook

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -16,7 +16,7 @@ case "$1" in
     sshcommand create dokku /usr/local/bin/dokku
     egrep -i "^docker" /etc/group || groupadd docker
     usermod -aG docker dokku
-    dokku plugins-install
+    echo "WARNING: Run 'dokku plugins-install' after installation if using custom plugins"
     rm -f /home/dokku/VERSION
     cp /var/lib/dokku/STABLE_VERSION /home/dokku/VERSION
 


### PR DESCRIPTION
All core plugins that require debian packages already have those packages specified in the `depends` stanza of the `control` file, so no need to respecify them here.