### PR TITLE
Revert "Remove `dokku plugins-install` from postinst hook"

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -16,7 +16,7 @@ case "$1" in
     sshcommand create dokku /usr/local/bin/dokku
     egrep -i "^docker" /etc/group || groupadd docker
     usermod -aG docker dokku
-    echo "WARNING: Run 'dokku plugins-install' after installation if using custom plugins"
+    dokku plugins-install
     rm -f /home/dokku/VERSION
     cp /var/lib/dokku/STABLE_VERSION /home/dokku/VERSION
 


### PR DESCRIPTION
This reverts commit 1bf30bdcb1d364e8356bd1a2bc8955d0c34e4409.

Commit was reverted as this breaks installs of core plugins. It is also a hack around broken plugins that don't use the `dependencies` pluginhook.