### PR TITLE
Consolidate config

### DIFF
--- a/docs/development/pluginhooks.md
+++ b/docs/development/pluginhooks.md
@@ -338,7 +338,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 CONTAINERID="$1"; APP="$2"; PORT="$3" ; HOSTNAME="${4:-localhost}"
 
-eval $(dokku config $APP --export)
+eval "$(dokku config $APP --export)"
 DOKKU_DISABLE_DEPLOY="${DOKKU_DISABLE_DEPLOY:-false}"
 
 if [[ "$DOKKU_DISABLE_DEPLOY" = "true" ]]; then

--- a/docs/development/pluginhooks.md
+++ b/docs/development/pluginhooks.md
@@ -338,7 +338,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 CONTAINERID="$1"; APP="$2"; PORT="$3" ; HOSTNAME="${4:-localhost}"
 
-[[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source $DOKKU_ROOT/$APP/ENV
+eval $(dokku config $APP --export)
 DOKKU_DISABLE_DEPLOY="${DOKKU_DISABLE_DEPLOY:-false}"
 
 if [[ "$DOKKU_DISABLE_DEPLOY" = "true" ]]; then

--- a/docs/development/pluginhooks.md
+++ b/docs/development/pluginhooks.md
@@ -335,6 +335,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 # `DOKKU_DISABLE_DEPLOY` env var is set to `true` for an app
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_PATH/config/functions"
 
 CONTAINERID="$1"; APP="$2"; PORT="$3" ; HOSTNAME="${4:-localhost}"
 

--- a/docs/development/pluginhooks.md
+++ b/docs/development/pluginhooks.md
@@ -339,7 +339,7 @@ source "$PLUGIN_PATH/config/functions"
 
 CONTAINERID="$1"; APP="$2"; PORT="$3" ; HOSTNAME="${4:-localhost}"
 
-eval "$(dokku config $APP --export)"
+eval "$(config_export app $APP)"
 DOKKU_DISABLE_DEPLOY="${DOKKU_DISABLE_DEPLOY:-false}"
 
 if [[ "$DOKKU_DISABLE_DEPLOY" = "true" ]]; then

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -67,7 +67,7 @@ case "$1" in
         pluginhook pre-release-buildstep "$APP"
         pluginhook pre-release-buildpack "$APP"
         if [[ -n $(config_export global) ]]; then
-          TMPFILE=$(mktemp /tmp/dokku.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
+          TMPFILE=$(mktemp $DOKKU_ROOT/$APP/.dokku_config.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
           config_export global > $TMPFILE
           id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh" < "$TMPFILE")
           test "$(docker wait $id)" -eq 0
@@ -75,7 +75,7 @@ case "$1" in
           rm -rf $TMPFILE
         fi
         if [[ -n $(config_export app $APP) ]]; then
-          TMPFILE=$(mktemp /tmp/dokku.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
+          TMPFILE=$(mktemp $DOKKU_ROOT/$APP/.dokku_config.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
           config_export app $APP > $TMPFILE
           id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh" < "$TMPFILE")
           test "$(docker wait $id)" -eq 0

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -7,7 +7,7 @@ case "$1" in
     APP="$2"; IMAGE="dokku/$APP"; IMAGE_SOURCE_TYPE="$3"; TMP_WORK_DIR="$4"
     CACHE_DIR="$DOKKU_ROOT/$APP/cache"
 
-    [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source "$DOKKU_ROOT/$APP/ENV"
+    eval $(dokku config $APP --export)
     pushd "$TMP_WORK_DIR" &> /dev/null
 
     case "$IMAGE_SOURCE_TYPE" in
@@ -185,7 +185,7 @@ case "$1" in
     verify_app_name "$2"
     APP="$2";
 
-    [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source "$DOKKU_ROOT/$APP/ENV"
+    eval $(dokku config $APP --export)
 
     if [[ -s "$DOKKU_ROOT/$APP/URLS" ]]; then
       case "$1" in

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -42,7 +42,7 @@ case "$1" in
       dockerfile)
         # extract first port from Dockerfile
         DOCKERFILE_PORT=$(get_dockerfile_exposed_port Dockerfile)
-        [[ -n "$DOCKERFILE_PORT" ]] && dokku config:set --no-restart $APP DOKKU_DOCKERFILE_PORT=$DOCKERFILE_PORT
+        [[ -n "$DOCKERFILE_PORT" ]] && config_set --no-restart $APP DOKKU_DOCKERFILE_PORT=$DOCKERFILE_PORT
         pluginhook pre-build-dockerfile "$APP"
 
         [[ "$DOKKU_DOCKERFILE_CACHE_BUILD" == "false" ]] && DOKKU_DOCKER_BUILD_OPTS="$DOKKU_DOCKER_BUILD_OPTS --no-cache"

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_PATH/common/functions"
+source "$PLUGIN_PATH/config/functions"
 
 case "$1" in
   build)
     APP="$2"; IMAGE="dokku/$APP"; IMAGE_SOURCE_TYPE="$3"; TMP_WORK_DIR="$4"
     CACHE_DIR="$DOKKU_ROOT/$APP/cache"
 
-    eval "$(dokku config $APP --export)"
+    eval "$(config_export app $APP)"
     pushd "$TMP_WORK_DIR" &> /dev/null
 
     case "$IMAGE_SOURCE_TYPE" in
@@ -65,17 +66,17 @@ case "$1" in
         # *DEPRECATED* in v0.3.22: `pluginhook pre-release-buildstep` will be removed in future releases
         pluginhook pre-release-buildstep "$APP"
         pluginhook pre-release-buildpack "$APP"
-        if [[ -n $(dokku config --global --export) ]]; then
+        if [[ -n $(config_export global) ]]; then
           TMPFILE=$(mktemp /tmp/dokku.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
-          dokku config --global --export > $TMPFILE
+          config_export global > $TMPFILE
           id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh" < "$TMPFILE")
           test "$(docker wait $id)" -eq 0
           docker commit $id $IMAGE > /dev/null
           rm -rf $TMPFILE
         fi
-        if [[ -n $(dokku config $APP --export) ]]; then
+        if [[ -n $(config_export app $APP) ]]; then
           TMPFILE=$(mktemp /tmp/dokku.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
-          dokku config $APP --export > $TMPFILE
+          config_export app $APP > $TMPFILE
           id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh" < "$TMPFILE")
           test "$(docker wait $id)" -eq 0
           docker commit $id $IMAGE > /dev/null
@@ -191,7 +192,7 @@ case "$1" in
     verify_app_name "$2"
     APP="$2";
 
-    eval "$(dokku config $APP --export)"
+    eval "$(config_export app $APP)"
 
     if [[ -s "$DOKKU_ROOT/$APP/URLS" ]]; then
       case "$1" in

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -67,16 +67,18 @@ case "$1" in
         pluginhook pre-release-buildstep "$APP"
         pluginhook pre-release-buildpack "$APP"
         if [[ -n $(config_export global) ]]; then
-          TMPFILE=$(mktemp $DOKKU_ROOT/$APP/.dokku_config.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
-          trap 'rm -rf "$TMPFILE" > /dev/null' RETURN
+          mkdir -p "$DOKKU_ROOT/$APP/.dokku/tmp"
+          TMPFILE=$(mktemp $DOKKU_ROOT/$APP/.dokku/tmp/.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
+          trap 'rm -rf "$TMPFILE" > /dev/null' INT TERM EXIT
           config_export global > $TMPFILE
           id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh" < "$TMPFILE")
           test "$(docker wait $id)" -eq 0
           docker commit $id $IMAGE > /dev/null
         fi
         if [[ -n $(config_export app $APP) ]]; then
-          TMPFILE=$(mktemp $DOKKU_ROOT/$APP/.dokku_config.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
-          trap 'rm -rf "$TMPFILE" > /dev/null' RETURN
+          mkdir -p "$DOKKU_ROOT/$APP/.dokku/tmp"
+          TMPFILE=$(mktemp $DOKKU_ROOT/$APP/.dokku/tmp/XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
+          trap 'rm -rf "$TMPFILE" > /dev/null' INT TERM EXIT
           config_export app $APP > $TMPFILE
           id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh" < "$TMPFILE")
           test "$(docker wait $id)" -eq 0

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -7,7 +7,7 @@ case "$1" in
     APP="$2"; IMAGE="dokku/$APP"; IMAGE_SOURCE_TYPE="$3"; TMP_WORK_DIR="$4"
     CACHE_DIR="$DOKKU_ROOT/$APP/cache"
 
-    eval $(dokku config $APP --export)
+    eval "$(dokku config $APP --export)"
     pushd "$TMP_WORK_DIR" &> /dev/null
 
     case "$IMAGE_SOURCE_TYPE" in
@@ -185,7 +185,7 @@ case "$1" in
     verify_app_name "$2"
     APP="$2";
 
-    eval $(dokku config $APP --export)
+    eval "$(dokku config $APP --export)"
 
     if [[ -s "$DOKKU_ROOT/$APP/URLS" ]]; then
       case "$1" in

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -65,15 +65,21 @@ case "$1" in
         # *DEPRECATED* in v0.3.22: `pluginhook pre-release-buildstep` will be removed in future releases
         pluginhook pre-release-buildstep "$APP"
         pluginhook pre-release-buildpack "$APP"
-        if [[ -f "$DOKKU_ROOT/ENV" ]]; then
-          id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh" < "$DOKKU_ROOT/ENV")
+        if [[ -n $(dokku config --global --export) ]]; then
+          TMPFILE=$(mktemp /tmp/dokku.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
+          dokku config --global --export > $TMPFILE
+          id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh" < "$TMPFILE")
           test "$(docker wait $id)" -eq 0
           docker commit $id $IMAGE > /dev/null
+          rm -rf $TMPFILE
         fi
-        if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
-          id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh" < "$DOKKU_ROOT/$APP/ENV")
+        if [[ -n $(dokku config $APP --export) ]]; then
+          TMPFILE=$(mktemp /tmp/dokku.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
+          dokku config $APP --export > $TMPFILE
+          id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh" < "$TMPFILE")
           test "$(docker wait $id)" -eq 0
           docker commit $id $IMAGE > /dev/null
+          rm -rf $TMPFILE
         fi
         # *DEPRECATED* in v0.3.15: `pluginhook post-release` will be removed in future releases
         pluginhook post-release "$APP"

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -67,20 +67,12 @@ case "$1" in
         pluginhook pre-release-buildstep "$APP"
         pluginhook pre-release-buildpack "$APP"
         if [[ -n $(config_export global) ]]; then
-          mkdir -p "$DOKKU_ROOT/$APP/.dokku/tmp"
-          TMPFILE=$(mktemp $DOKKU_ROOT/$APP/.dokku/tmp/.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
-          trap 'rm -rf "$TMPFILE" > /dev/null' INT TERM EXIT
-          config_export global > $TMPFILE
-          id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh" < "$TMPFILE")
+          id=$(config_export global | docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh")
           test "$(docker wait $id)" -eq 0
           docker commit $id $IMAGE > /dev/null
         fi
         if [[ -n $(config_export app $APP) ]]; then
-          mkdir -p "$DOKKU_ROOT/$APP/.dokku/tmp"
-          TMPFILE=$(mktemp $DOKKU_ROOT/$APP/.dokku/tmp/XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
-          trap 'rm -rf "$TMPFILE" > /dev/null' INT TERM EXIT
-          config_export app $APP > $TMPFILE
-          id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh" < "$TMPFILE")
+          id=$(config_export app $APP | docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh")
           test "$(docker wait $id)" -eq 0
           docker commit $id $IMAGE > /dev/null
         fi

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -68,19 +68,19 @@ case "$1" in
         pluginhook pre-release-buildpack "$APP"
         if [[ -n $(config_export global) ]]; then
           TMPFILE=$(mktemp $DOKKU_ROOT/$APP/.dokku_config.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
+          trap 'rm -rf "$TMPFILE" > /dev/null' RETURN
           config_export global > $TMPFILE
           id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/00-global-env.sh" < "$TMPFILE")
           test "$(docker wait $id)" -eq 0
           docker commit $id $IMAGE > /dev/null
-          rm -rf $TMPFILE
         fi
         if [[ -n $(config_export app $APP) ]]; then
           TMPFILE=$(mktemp $DOKKU_ROOT/$APP/.dokku_config.XXXXXX) || dokku_log_fail "Cannot create temp file using mktemp in /tmp dir"
+          trap 'rm -rf "$TMPFILE" > /dev/null' RETURN
           config_export app $APP > $TMPFILE
           id=$(docker run -i -a stdin $IMAGE /bin/bash -c "mkdir -p /app/.profile.d && cat > /app/.profile.d/01-app-env.sh" < "$TMPFILE")
           test "$(docker wait $id)" -eq 0
           docker commit $id $IMAGE > /dev/null
-          rm -rf $TMPFILE
         fi
         # *DEPRECATED* in v0.3.15: `pluginhook post-release` will be removed in future releases
         pluginhook post-release "$APP"

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -11,12 +11,12 @@ dokku config:get --global CURL_TIMEOUT > /dev/null 2>&1 || dokku config:set --gl
 
 if [[ -n $(dokku config --global --export) ]]; then
   BUILD_ENV+=$'\n'
-  BUILD_ENV+=$(< "$DOKKU_ROOT/ENV")
+  BUILD_ENV+=$(dokku config --global --export)
   BUILD_ENV+=$'\n'
 fi
 if [[ -n $(dokku config $APP --export) ]]; then
   BUILD_ENV+=$'\n'
-  BUILD_ENV+=$(< "$DOKKU_ROOT/$APP/ENV")
+  BUILD_ENV+=$(dokku config $APP --export)
   BUILD_ENV+=$'\n'
 fi
 

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_PATH/common/functions"
+source "$PLUGIN_PATH/config/functions"
 
 APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
 
@@ -12,14 +13,14 @@ APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
 dokku config:get --global CURL_CONNECT_TIMEOUT > /dev/null 2>&1 || dokku config:set --global CURL_CONNECT_TIMEOUT=5
 dokku config:get --global CURL_TIMEOUT > /dev/null 2>&1 || dokku config:set --global CURL_TIMEOUT=30
 
-if [[ -n $(dokku config --global --export) ]]; then
+if [[ -n $(config_export global) ]]; then
   BUILD_ENV+=$'\n'
-  BUILD_ENV+=$(dokku config --global --export)
+  BUILD_ENV+=$(config_export global)
   BUILD_ENV+=$'\n'
 fi
-if [[ -n $(dokku config $APP --export) ]]; then
+if [[ -n $(config_export app $APP) ]]; then
   BUILD_ENV+=$'\n'
-  BUILD_ENV+=$(dokku config $APP --export)
+  BUILD_ENV+=$(config_export app $APP)
   BUILD_ENV+=$'\n'
 fi
 

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -6,8 +6,8 @@ APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
 
 [[ -f "$DOKKU_ROOT/BUILD_ENV" ]] && cat "$DOKKU_ROOT/BUILD_ENV" >> "$DOKKU_ROOT/ENV" && rm "$DOKKU_ROOT/BUILD_ENV"
 
-! (grep -q CURL_CONNECT_TIMEOUT "$DOKKU_ROOT/ENV" > /dev/null 2>&1) && dokku config:set --global CURL_CONNECT_TIMEOUT=5
-! (grep -q CURL_TIMEOUT "$DOKKU_ROOT/ENV" > /dev/null 2>&1) && dokku config:set --global CURL_TIMEOUT=30
+dokku config:get --global CURL_CONNECT_TIMEOUT > /dev/null 2>&1 || dokku config:set --global CURL_CONNECT_TIMEOUT=5
+dokku config:get --global CURL_TIMEOUT > /dev/null 2>&1 || dokku config:set --global CURL_TIMEOUT=30
 
 if [[ -f "$DOKKU_ROOT/ENV" ]]; then
   BUILD_ENV+=$'\n'

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -4,7 +4,10 @@ source "$PLUGIN_PATH/common/functions"
 
 APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
 
-[[ -f "$DOKKU_ROOT/BUILD_ENV" ]] && cat "$DOKKU_ROOT/BUILD_ENV" >> "$DOKKU_ROOT/ENV" && rm "$DOKKU_ROOT/BUILD_ENV"
+[[ -f "$DOKKU_ROOT/BUILD_ENV" ]] && cat "$DOKKU_ROOT/BUILD_ENV" >> "$DOKKU_ROOT/ENV" && {
+  dokku_log_info2 "Using a global BUILD_ENV file is deprecated as of 0.3.26"
+  rm "$DOKKU_ROOT/BUILD_ENV"
+}
 
 dokku config:get --global CURL_CONNECT_TIMEOUT > /dev/null 2>&1 || dokku config:set --global CURL_CONNECT_TIMEOUT=5
 dokku config:get --global CURL_TIMEOUT > /dev/null 2>&1 || dokku config:set --global CURL_TIMEOUT=30

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -6,8 +6,8 @@ APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
 
 [[ -f "$DOKKU_ROOT/BUILD_ENV" ]] && cat "$DOKKU_ROOT/BUILD_ENV" >> "$DOKKU_ROOT/ENV" && rm "$DOKKU_ROOT/BUILD_ENV"
 
-! (grep -q CURL_CONNECT_TIMEOUT "$DOKKU_ROOT/ENV" > /dev/null 2>&1) && echo "export CURL_CONNECT_TIMEOUT=5" >> "$DOKKU_ROOT/ENV"
-! (grep -q CURL_TIMEOUT "$DOKKU_ROOT/ENV" > /dev/null 2>&1) && echo "export CURL_TIMEOUT=30" >> "$DOKKU_ROOT/ENV"
+! (grep -q CURL_CONNECT_TIMEOUT "$DOKKU_ROOT/ENV" > /dev/null 2>&1) && dokku config:set --global $APP CURL_CONNECT_TIMEOUT=5
+! (grep -q CURL_TIMEOUT "$DOKKU_ROOT/ENV" > /dev/null 2>&1) && dokku config:set --global $APP CURL_TIMEOUT=30
 
 if [[ -f "$DOKKU_ROOT/ENV" ]]; then
   BUILD_ENV+=$'\n'

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -9,12 +9,12 @@ APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
 dokku config:get --global CURL_CONNECT_TIMEOUT > /dev/null 2>&1 || dokku config:set --global CURL_CONNECT_TIMEOUT=5
 dokku config:get --global CURL_TIMEOUT > /dev/null 2>&1 || dokku config:set --global CURL_TIMEOUT=30
 
-if [[ -f "$DOKKU_ROOT/ENV" ]]; then
+if [[ -n $(dokku config --global --export) ]]; then
   BUILD_ENV+=$'\n'
   BUILD_ENV+=$(< "$DOKKU_ROOT/ENV")
   BUILD_ENV+=$'\n'
 fi
-if [[ -f "$DOKKU_ROOT/$APP/ENV" ]]; then
+if [[ -n $(dokku config $APP --export) ]]; then
   BUILD_ENV+=$'\n'
   BUILD_ENV+=$(< "$DOKKU_ROOT/$APP/ENV")
   BUILD_ENV+=$'\n'

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -6,8 +6,8 @@ APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
 
 [[ -f "$DOKKU_ROOT/BUILD_ENV" ]] && cat "$DOKKU_ROOT/BUILD_ENV" >> "$DOKKU_ROOT/ENV" && rm "$DOKKU_ROOT/BUILD_ENV"
 
-! (grep -q CURL_CONNECT_TIMEOUT "$DOKKU_ROOT/ENV" > /dev/null 2>&1) && dokku config:set --global $APP CURL_CONNECT_TIMEOUT=5
-! (grep -q CURL_TIMEOUT "$DOKKU_ROOT/ENV" > /dev/null 2>&1) && dokku config:set --global $APP CURL_TIMEOUT=30
+! (grep -q CURL_CONNECT_TIMEOUT "$DOKKU_ROOT/ENV" > /dev/null 2>&1) && dokku config:set --global CURL_CONNECT_TIMEOUT=5
+! (grep -q CURL_TIMEOUT "$DOKKU_ROOT/ENV" > /dev/null 2>&1) && dokku config:set --global CURL_TIMEOUT=30
 
 if [[ -f "$DOKKU_ROOT/ENV" ]]; then
   BUILD_ENV+=$'\n'

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -10,8 +10,8 @@ APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
   rm "$DOKKU_ROOT/BUILD_ENV"
 }
 
-dokku config:get --global CURL_CONNECT_TIMEOUT > /dev/null 2>&1 || dokku config:set --global CURL_CONNECT_TIMEOUT=5
-dokku config:get --global CURL_TIMEOUT > /dev/null 2>&1 || dokku config:set --global CURL_TIMEOUT=30
+config_get --global CURL_CONNECT_TIMEOUT > /dev/null 2>&1 || config_set --global CURL_CONNECT_TIMEOUT=5
+config_get --global CURL_TIMEOUT > /dev/null 2>&1 || config_set --global CURL_TIMEOUT=30
 
 if [[ -n $(config_export global) ]]; then
   BUILD_ENV+=$'\n'

--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -51,8 +51,8 @@ fi
 
 
 # source global and in-app envs to get DOKKU_CHECKS_WAIT and any other necessary vars
-eval $(dokku config --global $APP --export)
-eval $(dokku config $APP --export)
+eval "$(dokku config --global $APP --export)"
+eval "$(dokku config $APP --export)"
 
 # Wait this many seconds (default 5) for server to start before running checks.
 WAIT="${DOKKU_CHECKS_WAIT:-5}"

--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -36,6 +36,7 @@
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_PATH/common/functions"
+source "$PLUGIN_PATH/config/functions"
 
 APP="$1"; DOKKU_APP_CONTAINER_ID="$2"; DOKKU_APP_CONTAINER_TYPE="$3"; DOKKU_APP_LISTEN_PORT="$4"; DOKKU_APP_LISTEN_IP="$5"
 if [[ -z "$DOKKU_APP_LISTEN_PORT" ]] && [[ -f "$DOKKU_ROOT/$APP/PORT" ]]; then
@@ -51,8 +52,8 @@ fi
 
 
 # source global and in-app envs to get DOKKU_CHECKS_WAIT and any other necessary vars
-eval "$(dokku config --global $APP --export)"
-eval "$(dokku config $APP --export)"
+eval "$(config_export global)"
+eval "$(config_export app $APP)"
 
 # Wait this many seconds (default 5) for server to start before running checks.
 WAIT="${DOKKU_CHECKS_WAIT:-5}"

--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -51,8 +51,8 @@ fi
 
 
 # source global and in-app envs to get DOKKU_CHECKS_WAIT and any other necessary vars
-[[ -f "$DOKKU_ROOT/ENV" ]] && source $DOKKU_ROOT/ENV
-[[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source $DOKKU_ROOT/$APP/ENV
+eval $(dokku config --global $APP --export)
+eval $(dokku config $APP --export)
 
 # Wait this many seconds (default 5) for server to start before running checks.
 WAIT="${DOKKU_CHECKS_WAIT:-5}"

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -3,53 +3,6 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_PATH/common/functions"
 source "$PLUGIN_PATH/config/functions"
 
-config_styled_hash () {
-  vars="$1"
-  prefix="$2"
-
-  longest=""
-  while read -r word; do
-    KEY=$(echo $word | cut -d"=" -f1)
-    if [ ${#KEY} -gt ${#longest} ]; then
-      longest=$KEY
-    fi
-  done <<< "$vars"
-
-  while read -r word; do
-    KEY=$(echo $word | cut -d"=" -f1)
-    VALUE=$(echo $word | cut -d"=" -f2- | sed -e "s/^'//" -e "s/'$//" -e "s/\$$//g")
-
-    num_zeros=$((${#longest} - ${#KEY}))
-    zeros=" "
-    while [ $num_zeros -gt 0 ]; do
-      zeros="$zeros "
-      num_zeros=$((num_zeros - 1))
-    done
-    echo "$prefix$KEY:$zeros$VALUE"
-  done <<< "$vars"
-}
-
-config_write() {
-  ENV_TEMP="$1"
-  ENV_FILE_TEMP="${ENV_FILE}.tmp"
-
-  echo "$ENV_TEMP" | sed '/^$/d' | sort > $ENV_FILE_TEMP
-  if ! cmp -s $ENV_FILE $ENV_FILE_TEMP; then
-    cp -f $ENV_FILE_TEMP $ENV_FILE
-    chmod 600 $ENV_FILE
-  fi
-  rm -f $ENV_FILE_TEMP
-}
-
-is_config_export() {
-  for var in "$@"; do
-    if [[ "$var" == "--export" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
 case "$1" in
   config)
     config_parse_args "$@"

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -27,75 +27,11 @@ case "$1" in
     ;;
 
   config:get)
-    config_parse_args "$@"
-
-    if [[ -z $3 ]]; then
-      echo "Usage: dokku config:get APP KEY"
-      echo "Must specify KEY."
-      exit 1
-    fi
-
-    config_create "$ENV_FILE"
-    if [[ ! -s $ENV_FILE ]] ; then
-      exit 0
-    fi
-
-    KEY="$3"
-
-    grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" $ENV_FILE | grep "^export $KEY=" | cut -d"=" -f2- | sed -e "s/^'//" -e "s/'$//"
+    config_get "$@"
     ;;
 
   config:set)
-    config_parse_args "$@"
-    [[ "$2" = "--no-restart" ]] && set -- "${@:1:1}" "${@:3}"
-
-    if [[ -z "${*:3}" ]]; then
-      echo "Usage: dokku config:set APP KEY1=VALUE1 [KEY2=VALUE2 ...]"
-      echo "Must specify KEY and VALUE to set."
-      exit 1
-    fi
-
-    config_create "$ENV_FILE"
-    ENV_ADD=""
-    ENV_TEMP=$(cat "${ENV_FILE}")
-    RESTART_APP=false
-    shift 2
-
-    for var; do
-      if [[ $var != *"="* ]]; then
-        echo "Usage: dokku config:set APP KEY1=VALUE1 [KEY2=VALUE2 ...]"
-        echo "Must specify KEY and VALUE to set."
-        exit 1
-      fi
-    done
-
-    for var; do
-      KEY=$(echo ${var} | cut -d"=" -f1)
-      VALUE=$(echo ${var} | cut -d"=" -f2-)
-
-      if [[ $KEY =~ [a-zA-Z_][a-zA-Z0-9_]* ]]; then
-        RESTART_APP=true
-        ENV_TEMP=$(echo "${ENV_TEMP}" | sed "/^export $KEY=/ d")
-        ENV_TEMP="${ENV_TEMP}
-export $KEY='$VALUE'"
-        ENV_ADD=$(echo -e "${ENV_ADD}" | sed "/^$KEY=/ d")
-        ENV_ADD="${ENV_ADD}$
-${var}"
-      fi
-    done
-    ENV_ADD=$(echo "$ENV_ADD" | tail -n +2) #remove first empty line
-
-    if [ $RESTART_APP ]; then
-      dokku_log_info1 "Setting config vars"
-      config_styled_hash "$ENV_ADD" "       "
-
-      config_write "$ENV_TEMP"
-    fi
-
-    if [[ "$DOKKU_CONFIG_RESTART" == "true" ]]; then
-      dokku_log_info1 "Restarting app $APP"
-      dokku ps:restart $APP
-    fi
+    config_set "$@"
     ;;
 
   config:unset)

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -5,25 +5,7 @@ source "$PLUGIN_PATH/config/functions"
 
 case "$1" in
   config)
-    config_parse_args "$@"
-    config_create "$ENV_FILE"
-    is_config_export "$@" && config_export "$DOKKU_CONFIG_TYPE" "$APP" && exit 0
-
-    [[ "$APP" ]] && DOKKU_CONFIG_TYPE=$APP
-    [[ ! -s $ENV_FILE ]] && echo "no config vars for $DOKKU_CONFIG_TYPE" && exit 1
-
-    VARS=$(grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" $ENV_FILE | cut -d" " -f2-)
-
-    for var in "$@"; do
-      if [[ "$var" == "--shell" ]]; then
-        echo $VARS
-        exit 0
-      fi
-    done
-
-
-    dokku_log_info2_quiet "$DOKKU_CONFIG_TYPE config vars"
-    config_styled_hash "$VARS"
+    config_all "$@"
     ;;
 
   config:get)
@@ -35,30 +17,7 @@ case "$1" in
     ;;
 
   config:unset)
-    config_parse_args "$@"
-    [[ "$2" = "--no-restart" ]] && set -- "${@:1:1}" "${@:3}"
-
-    if [[ -z $3 ]]; then
-      echo "Usage: dokku config:unset APP KEY1 [KEY2 ...]"
-      echo "Must specify KEY to unset."
-      exit 1
-    fi
-
-    config_create "$ENV_FILE"
-    ENV_TEMP=$(cat "${ENV_FILE}")
-    VARS="${*:3}"
-
-    for var in $VARS; do
-      dokku_log_info1 "Unsetting $var"
-      ENV_TEMP=$(echo -e "${ENV_TEMP}" | sed "/^export $var=/ d")
-
-      config_write "$ENV_TEMP"
-    done
-
-    if [[ "$DOKKU_CONFIG_RESTART" == "true" ]]; then
-      dokku_log_info1 "Restarting app $APP"
-      dokku ps:restart $APP
-    fi
+    config_unset "$@"
     ;;
 
   config:set-norestart)

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -59,7 +59,7 @@ is_config_export() {
 case "$1" in
   config)
     config_parse_args "$@"
-    config_create
+    config_create "$ENV_FILE"
     is_config_export "$@" && config_export "$DOKKU_CONFIG_TYPE" "$APP" && exit 0
 
     [[ "$APP" ]] && DOKKU_CONFIG_TYPE=$APP
@@ -88,7 +88,7 @@ case "$1" in
       exit 1
     fi
 
-    config_create
+    config_create "$ENV_FILE"
     if [[ ! -s $ENV_FILE ]] ; then
       exit 0
     fi
@@ -108,7 +108,7 @@ case "$1" in
       exit 1
     fi
 
-    config_create
+    config_create "$ENV_FILE"
     ENV_ADD=""
     ENV_TEMP=$(cat "${ENV_FILE}")
     RESTART_APP=false
@@ -161,7 +161,7 @@ ${var}"
       exit 1
     fi
 
-    config_create
+    config_create "$ENV_FILE"
     ENV_TEMP=$(cat "${ENV_FILE}")
     VARS="${*:3}"
 

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_PATH/common/functions"
+source "$PLUGIN_PATH/config/functions"
 
 config_create () {
   [ -f $ENV_FILE ] || {
@@ -46,36 +47,6 @@ config_write() {
   rm -f $ENV_FILE_TEMP
 }
 
-parse_config_args() {
-  case "$2" in
-    --global)
-      ENV_FILE="$DOKKU_ROOT/ENV"
-      DOKKU_CONFIG_TYPE="global"
-      DOKKU_CONFIG_RESTART=false
-      ;;
-    --no-restart)
-      APP="$3"
-      ENV_FILE="$DOKKU_ROOT/$APP/ENV"
-      DOKKU_CONFIG_RESTART=false
-      DOKKU_CONFIG_TYPE="app"
-      set -- "${@:1:1}" "${@:3}"
-  esac
-
-  APP=${APP:="$2"}
-  ENV_FILE=${ENV_FILE:="$DOKKU_ROOT/$APP/ENV"}
-  DOKKU_CONFIG_TYPE=${DOKKU_CONFIG_TYPE:="app"}
-  DOKKU_CONFIG_RESTART=${DOKKU_CONFIG_RESTART:=true}
-
-  if [[ "$DOKKU_CONFIG_TYPE" = "app" ]]; then
-    if [[ -z $APP ]]; then
-      echo "Please specify an app to run the command on" >&2 && exit 1
-    else
-      verify_app_name "$2"
-    fi
-  fi
-  export APP ENV_FILE DOKKU_CONFIG_TYPE DOKKU_CONFIG_RESTART
-}
-
 is_config_export() {
   for var in "$@"; do
     if [[ "$var" == "--export" ]]; then
@@ -87,7 +58,7 @@ is_config_export() {
 
 case "$1" in
   config)
-    parse_config_args "$@"
+    config_parse_args "$@"
     config_create
     is_config_export "$@" && config_export "$DOKKU_CONFIG_TYPE" "$APP" && exit 0
 
@@ -109,7 +80,7 @@ case "$1" in
     ;;
 
   config:get)
-    parse_config_args "$@"
+    config_parse_args "$@"
 
     if [[ -z $3 ]]; then
       echo "Usage: dokku config:get APP KEY"
@@ -128,7 +99,7 @@ case "$1" in
     ;;
 
   config:set)
-    parse_config_args "$@"
+    config_parse_args "$@"
     [[ "$2" = "--no-restart" ]] && set -- "${@:1:1}" "${@:3}"
 
     if [[ -z "${*:3}" ]]; then
@@ -181,7 +152,7 @@ ${var}"
     ;;
 
   config:unset)
-    parse_config_args "$@"
+    config_parse_args "$@"
     [[ "$2" = "--no-restart" ]] && set -- "${@:1:1}" "${@:3}"
 
     if [[ -z $3 ]]; then

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -76,12 +76,22 @@ parse_config_args() {
   export APP ENV_FILE DOKKU_CONFIG_TYPE DOKKU_CONFIG_RESTART
 }
 
+is_config_export() {
+  for var in "$@"; do
+    if [[ "$var" == "--export" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 case "$1" in
   config)
     parse_config_args "$@"
     config_create
 
     [[ "$APP" ]] && DOKKU_CONFIG_TYPE=$APP
+    [[ ! -s $ENV_FILE ]] && is_config_export $@ && exit 0
     [[ ! -s $ENV_FILE ]] && echo "no config vars for $DOKKU_CONFIG_TYPE" && exit 1
 
     VARS=$(grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" $ENV_FILE | cut -d" " -f2-)

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -91,7 +91,7 @@ case "$1" in
     config_create
 
     [[ "$APP" ]] && DOKKU_CONFIG_TYPE=$APP
-    [[ ! -s $ENV_FILE ]] && is_config_export $@ && exit 0
+    [[ ! -s $ENV_FILE ]] && is_config_export "$@" && exit 0
     [[ ! -s $ENV_FILE ]] && echo "no config vars for $DOKKU_CONFIG_TYPE" && exit 1
 
     VARS=$(grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" $ENV_FILE | cut -d" " -f2-)

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -91,6 +91,10 @@ case "$1" in
         echo $VARS
         exit 0
       fi
+      if [[ "$var" == "--export" ]]; then
+        echo "$VARS" | awk '{print "export " $0}'
+        exit 0
+      fi
     done
 
 

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -3,12 +3,6 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_PATH/common/functions"
 source "$PLUGIN_PATH/config/functions"
 
-config_create () {
-  [ -f $ENV_FILE ] || {
-    touch $ENV_FILE
-  }
-}
-
 config_styled_hash () {
   vars="$1"
   prefix="$2"

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -89,9 +89,9 @@ case "$1" in
   config)
     parse_config_args "$@"
     config_create
+    is_config_export "$@" && config_export "$DOKKU_CONFIG_TYPE" "$APP" && exit 0
 
     [[ "$APP" ]] && DOKKU_CONFIG_TYPE=$APP
-    [[ ! -s $ENV_FILE ]] && is_config_export "$@" && exit 0
     [[ ! -s $ENV_FILE ]] && echo "no config vars for $DOKKU_CONFIG_TYPE" && exit 1
 
     VARS=$(grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" $ENV_FILE | cut -d" " -f2-)
@@ -99,10 +99,6 @@ case "$1" in
     for var in "$@"; do
       if [[ "$var" == "--shell" ]]; then
         echo $VARS
-        exit 0
-      fi
-      if [[ "$var" == "--export" ]]; then
-        echo "$VARS" | awk '{print "export " $0}'
         exit 0
       fi
     done

--- a/plugins/config/docker-args-deploy
+++ b/plugins/config/docker-args-deploy
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_PATH/common/functions"
+source "$PLUGIN_PATH/config/functions"
 
 STDIN=$(cat); APP="$1"; IMAGE="dokku/$APP"
 DOCKERFILE_ENV_FILE="$DOKKU_ROOT/$APP/DOCKERFILE_ENV_FILE"
 
 if ! is_image_herokuish_based "$IMAGE"; then
   > "$DOCKERFILE_ENV_FILE"
-  dokku config --global --export | sed -e "s:^export ::g" -e "s:=':=:g" -e "s:'$::g" > "$DOCKERFILE_ENV_FILE"
-  dokku config "$APP" --export | sed -e "s:^export ::g" -e "s:=':=:g" -e "s:'$::g" >> "$DOCKERFILE_ENV_FILE"
+  config_export global | sed -e "s:^export ::g" -e "s:=':=:g" -e "s:'$::g" > "$DOCKERFILE_ENV_FILE"
+  config_export app $APP | sed -e "s:^export ::g" -e "s:=':=:g" -e "s:'$::g" >> "$DOCKERFILE_ENV_FILE"
 
   echo "$STDIN --env-file=$DOCKERFILE_ENV_FILE"
 else

--- a/plugins/config/docker-args-deploy
+++ b/plugins/config/docker-args-deploy
@@ -7,8 +7,8 @@ DOCKERFILE_ENV_FILE="$DOKKU_ROOT/$APP/DOCKERFILE_ENV_FILE"
 
 if ! is_image_herokuish_based "$IMAGE"; then
   > "$DOCKERFILE_ENV_FILE"
-  [[ -f "$DOKKU_ROOT/ENV" ]] && sed -e "s:^export ::g" -e "s:=':=:g" -e "s:'$::g" "$DOKKU_ROOT/ENV" > "$DOCKERFILE_ENV_FILE"
-  [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && sed -e "s:^export ::g" -e "s:=':=:g" -e "s:'$::g" "$DOKKU_ROOT/$APP/ENV" >> "$DOCKERFILE_ENV_FILE"
+  dokku config --global --export | sed -e "s:^export ::g" -e "s:=':=:g" -e "s:'$::g" > "$DOCKERFILE_ENV_FILE"
+  dokku config "$APP" --export | sed -e "s:^export ::g" -e "s:=':=:g" -e "s:'$::g" >> "$DOCKERFILE_ENV_FILE"
 
   echo "$STDIN --env-file=$DOCKERFILE_ENV_FILE"
 else

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -15,3 +15,33 @@ config_export() {
   echo "$VARS" | awk '{print "export " $0}'
   return 0
 }
+
+config_parse_args() {
+  case "$2" in
+    --global)
+      ENV_FILE="$DOKKU_ROOT/ENV"
+      DOKKU_CONFIG_TYPE="global"
+      DOKKU_CONFIG_RESTART=false
+      ;;
+    --no-restart)
+      APP="$3"
+      ENV_FILE="$DOKKU_ROOT/$APP/ENV"
+      DOKKU_CONFIG_RESTART=false
+      DOKKU_CONFIG_TYPE="app"
+      set -- "${@:1:1}" "${@:3}"
+  esac
+
+  APP=${APP:="$2"}
+  ENV_FILE=${ENV_FILE:="$DOKKU_ROOT/$APP/ENV"}
+  DOKKU_CONFIG_TYPE=${DOKKU_CONFIG_TYPE:="app"}
+  DOKKU_CONFIG_RESTART=${DOKKU_CONFIG_RESTART:=true}
+
+  if [[ "$DOKKU_CONFIG_TYPE" = "app" ]]; then
+    if [[ -z $APP ]]; then
+      echo "Please specify an app to run the command on" >&2 && exit 1
+    else
+      verify_app_name "$2"
+    fi
+  fi
+  export APP ENV_FILE DOKKU_CONFIG_TYPE DOKKU_CONFIG_RESTART
+}

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -97,3 +97,77 @@ is_config_export() {
   done
   return 1
 }
+
+config_get() {
+  [[ "$1" == "config:get" ]] || set -- "config:get" "$@"
+  config_parse_args "$@"
+
+  if [[ -z $3 ]]; then
+    echo "Usage: dokku config:get APP KEY"
+    echo "Must specify KEY."
+    exit 1
+  fi
+
+  config_create "$ENV_FILE"
+  if [[ ! -s $ENV_FILE ]] ; then
+    exit 0
+  fi
+
+  KEY="$3"
+
+  grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" $ENV_FILE | grep "^export $KEY=" | cut -d"=" -f2- | sed -e "s/^'//" -e "s/'$//"
+}
+
+config_set() {
+  [[ "$1" == "config:set" ]] || set -- "config:set" "$@"
+  config_parse_args "$@"
+  [[ "$2" = "--no-restart" ]] && set -- "${@:1:1}" "${@:3}"
+
+  if [[ -z "${*:3}" ]]; then
+    echo "Usage: dokku config:set APP KEY1=VALUE1 [KEY2=VALUE2 ...]"
+    echo "Must specify KEY and VALUE to set."
+    exit 1
+  fi
+
+  config_create "$ENV_FILE"
+  ENV_ADD=""
+  ENV_TEMP=$(cat "${ENV_FILE}")
+  RESTART_APP=false
+  shift 2
+
+  for var; do
+    if [[ $var != *"="* ]]; then
+      echo "Usage: dokku config:set APP KEY1=VALUE1 [KEY2=VALUE2 ...]"
+      echo "Must specify KEY and VALUE to set."
+      exit 1
+    fi
+  done
+
+  for var; do
+    KEY=$(echo ${var} | cut -d"=" -f1)
+    VALUE=$(echo ${var} | cut -d"=" -f2-)
+
+    if [[ $KEY =~ [a-zA-Z_][a-zA-Z0-9_]* ]]; then
+      RESTART_APP=true
+      ENV_TEMP=$(echo "${ENV_TEMP}" | sed "/^export $KEY=/ d")
+      ENV_TEMP="${ENV_TEMP}
+export $KEY='$VALUE'"
+      ENV_ADD=$(echo -e "${ENV_ADD}" | sed "/^$KEY=/ d")
+      ENV_ADD="${ENV_ADD}$
+${var}"
+    fi
+  done
+  ENV_ADD=$(echo "$ENV_ADD" | tail -n +2) #remove first empty line
+
+  if [ $RESTART_APP ]; then
+    dokku_log_info1 "Setting config vars"
+    config_styled_hash "$ENV_ADD" "       "
+
+    config_write "$ENV_TEMP"
+  fi
+
+  if [[ "$DOKKU_CONFIG_RESTART" == "true" ]]; then
+    dokku_log_info1 "Restarting app $APP"
+    dokku ps:restart $APP
+  fi
+}

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -50,3 +50,50 @@ config_create () {
   local ENV_FILE=$1
   [ -f $ENV_FILE ] || touch $ENV_FILE
 }
+
+config_styled_hash () {
+  local vars="$1"
+  local prefix="$2"
+  local longest=""
+
+  while read -r word; do
+    KEY=$(echo $word | cut -d"=" -f1)
+    if [ ${#KEY} -gt ${#longest} ]; then
+      longest=$KEY
+    fi
+  done <<< "$vars"
+
+  while read -r word; do
+    KEY=$(echo $word | cut -d"=" -f1)
+    VALUE=$(echo $word | cut -d"=" -f2- | sed -e "s/^'//" -e "s/'$//" -e "s/\$$//g")
+
+    num_zeros=$((${#longest} - ${#KEY}))
+    zeros=" "
+    while [ $num_zeros -gt 0 ]; do
+      zeros="$zeros "
+      num_zeros=$((num_zeros - 1))
+    done
+    echo "$prefix$KEY:$zeros$VALUE"
+  done <<< "$vars"
+}
+
+config_write() {
+  local ENV_TEMP="$1"
+  local ENV_FILE_TEMP="${ENV_FILE}.tmp"
+
+  echo "$ENV_TEMP" | sed '/^$/d' | sort > $ENV_FILE_TEMP
+  if ! cmp -s $ENV_FILE $ENV_FILE_TEMP; then
+    cp -f $ENV_FILE_TEMP $ENV_FILE
+    chmod 600 $ENV_FILE
+  fi
+  rm -f $ENV_FILE_TEMP
+}
+
+is_config_export() {
+  for var in "$@"; do
+    if [[ "$var" == "--export" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -98,6 +98,28 @@ is_config_export() {
   return 1
 }
 
+config_all() {
+  [[ "$1" == "config" ]] || set -- "config" "$@"
+  config_parse_args "$@"
+  config_create "$ENV_FILE"
+  is_config_export "$@" && config_export "$DOKKU_CONFIG_TYPE" "$APP" && exit 0
+
+  [[ "$APP" ]] && DOKKU_CONFIG_TYPE=$APP
+  [[ ! -s $ENV_FILE ]] && echo "no config vars for $DOKKU_CONFIG_TYPE" && exit 1
+
+  VARS=$(grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" $ENV_FILE | cut -d" " -f2-)
+
+  for var in "$@"; do
+    if [[ "$var" == "--shell" ]]; then
+      echo $VARS
+      exit 0
+    fi
+  done
+
+  dokku_log_info2_quiet "$DOKKU_CONFIG_TYPE config vars"
+  config_styled_hash "$VARS"
+}
+
 config_get() {
   [[ "$1" == "config:get" ]] || set -- "config:get" "$@"
   config_parse_args "$@"
@@ -170,4 +192,33 @@ ${var}"
     dokku_log_info1 "Restarting app $APP"
     dokku ps:restart $APP
   fi
+}
+
+config_unset() {
+  [[ "$1" == "config:unset" ]] || set -- "config:unset" "$@"
+  config_parse_args "$@"
+  [[ "$2" = "--no-restart" ]] && set -- "${@:1:1}" "${@:3}"
+
+  if [[ -z $3 ]]; then
+    echo "Usage: dokku config:unset APP KEY1 [KEY2 ...]"
+    echo "Must specify KEY to unset."
+    exit 1
+  fi
+
+  config_create "$ENV_FILE"
+  ENV_TEMP=$(cat "${ENV_FILE}")
+  VARS="${*:3}"
+
+  for var in $VARS; do
+    dokku_log_info1 "Unsetting $var"
+    ENV_TEMP=$(echo -e "${ENV_TEMP}" | sed "/^export $var=/ d")
+
+    config_write "$ENV_TEMP"
+  done
+
+  if [[ "$DOKKU_CONFIG_RESTART" == "true" ]]; then
+    dokku_log_info1 "Restarting app $APP"
+    dokku ps:restart $APP
+  fi
+
 }

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_PATH/common/functions"
+
+config_export() {
+  local CONFIG_TYPE="$1"
+  local APP="$2"
+  local ENV_FILE="$DOKKU_ROOT/$APP/ENV"
+
+  [[ $CONFIG_TYPE == "global" ]] && ENV_FILE="$DOKKU_ROOT/ENV"
+  [[ ! -f $ENV_FILE ]] && return 0
+  [[ ! -s $ENV_FILE ]] && return 0
+
+  VARS=$(grep -Eo "export ([a-zA-Z_][a-zA-Z0-9_]*=.*)" $ENV_FILE | cut -d" " -f2-)
+  echo "$VARS" | awk '{print "export " $0}'
+  return 0
+}

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -45,3 +45,8 @@ config_parse_args() {
   fi
   export APP ENV_FILE DOKKU_CONFIG_TYPE DOKKU_CONFIG_RESTART
 }
+
+config_create () {
+  local ENV_FILE=$1
+  [ -f $ENV_FILE ] || touch $ENV_FILE
+}

--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_PATH/common/functions"
+source "$PLUGIN_PATH/config/functions"
 
 RE_IPV4="([0-9]{1,3}[\.]){3}[0-9]{1,3}"
 
@@ -50,7 +51,7 @@ case "$1" in
       fi
       if [[ "$VHOST" =~ $RE_IPV4 ]] || [[ "$VHOST" =~ $RE_IPV6 ]];then
         dokku_log_info2 "unsupported vhost config found. disabling vhost support"
-        dokku config:set --no-restart $APP NO_VHOST=1
+        config_set --no-restart $APP NO_VHOST=1
       else
         if [[ -f "$DOKKU_ROOT/VHOST" ]]; then
           dokku_log_info1 "Creating new $VHOST_PATH..."

--- a/plugins/nginx-vhosts/bind-external-ip
+++ b/plugins/nginx-vhosts/bind-external-ip
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+source "$PLUGIN_PATH/config/functions"
 
 APP="$1"
-NO_VHOST=$(dokku config:get $APP NO_VHOST || true)
+NO_VHOST=$(config_get $APP NO_VHOST || true)
 
 RE_IPV4="([0-9]{1,3}[\.]){3}[0-9]{1,3}"
 

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -52,8 +52,8 @@ case "$1" in
     DOKKU_APP_CIDS=($(get_app_container_ids $APP))
     docker cp "${DOKKU_APP_CIDS[0]}:/app/nginx.conf.template" "$DOKKU_ROOT/$APP/" 2> /dev/null || true
 
-    eval $(dokku config --global $APP --export)
-    eval $(dokku config $APP --export)
+    eval "$(dokku config --global $APP --export)"
+    eval "$(dokku config $APP --export)"
     [[ -f "$APP_NGINX_TEMPLATE" ]] && NGINX_TEMPLATE="$APP_NGINX_TEMPLATE" && NGINX_CUSTOM_TEMPLATE="true" && dokku_log_info1 'Overriding default nginx.conf with detected nginx.conf.template'
 
     if [[ ! -n "$NO_VHOST" ]] && [[ -f "$DOKKU_ROOT/$APP/VHOST" ]]; then

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -52,8 +52,8 @@ case "$1" in
     DOKKU_APP_CIDS=($(get_app_container_ids $APP))
     docker cp "${DOKKU_APP_CIDS[0]}:/app/nginx.conf.template" "$DOKKU_ROOT/$APP/" 2> /dev/null || true
 
-    [[ -f "$DOKKU_ROOT/ENV" ]] && source $DOKKU_ROOT/ENV
-    [[ -f "$DOKKU_ROOT/$APP/ENV" ]] && source $DOKKU_ROOT/$APP/ENV
+    eval $(dokku config --global $APP --export)
+    eval $(dokku config $APP --export)
     [[ -f "$APP_NGINX_TEMPLATE" ]] && NGINX_TEMPLATE="$APP_NGINX_TEMPLATE" && NGINX_CUSTOM_TEMPLATE="true" && dokku_log_info1 'Overriding default nginx.conf with detected nginx.conf.template'
 
     if [[ ! -n "$NO_VHOST" ]] && [[ -f "$DOKKU_ROOT/$APP/VHOST" ]]; then

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_PATH/common/functions"
+source "$PLUGIN_PATH/config/functions"
 
 validate_nginx () {
   set +e
@@ -52,8 +53,8 @@ case "$1" in
     DOKKU_APP_CIDS=($(get_app_container_ids $APP))
     docker cp "${DOKKU_APP_CIDS[0]}:/app/nginx.conf.template" "$DOKKU_ROOT/$APP/" 2> /dev/null || true
 
-    eval "$(dokku config --global $APP --export)"
-    eval "$(dokku config $APP --export)"
+    eval "$(config_export global)"
+    eval "$(config_export app $APP)"
     [[ -f "$APP_NGINX_TEMPLATE" ]] && NGINX_TEMPLATE="$APP_NGINX_TEMPLATE" && NGINX_CUSTOM_TEMPLATE="true" && dokku_log_info1 'Overriding default nginx.conf with detected nginx.conf.template'
 
     if [[ ! -n "$NO_VHOST" ]] && [[ -f "$DOKKU_ROOT/$APP/VHOST" ]]; then

--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_PATH/common/functions"
+source "$PLUGIN_PATH/config/functions"
 
 APP="$1"
 if [[ -f "$DOKKU_ROOT/$APP/IP.web.1" ]] && [[ -f "$DOKKU_ROOT/$APP/PORT.web.1" ]]; then
-  NO_VHOST=$(dokku config:get $APP NO_VHOST || true)
+  NO_VHOST=$(config_get $APP NO_VHOST || true)
 
   if [[ -n "$NO_VHOST" ]]; then
     dokku_log_info1 "NO_VHOST config detected"


### PR DESCRIPTION
This PR is an attempt at consolidating configuration retrieval and setting within the `config` plugin. This would enable developers to replace their `config` plugin with another plugin, one potentially backed by a database, and therefore would allow users to deploy a cluster of dokku instances backed by a single configuration database.

- Added the `--export` option to `dokku config`.
- Switch to config:set where possible.
- Use `eval` (oooo evil) to set config env vars in the current context.

Todo:

- Remove all remaining checks for `ENV` files.
- Add `dokku config:has ENV_VAR` method.
- Fix cases where we are concatenating the raw `ENV` files for docker container runs.