### PR TITLE
Add links to official dokku datastorage plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -29,9 +29,12 @@ The following plugins are available and provided by dokku maintainers. Where not
 | [Elasticsearch (beta)](https://github.com/dokku/dokku-elasticsearch-plugin)                       | [dokku][]             | 0.3.25+               |
 | [MariaDB (beta)](https://github.com/dokku/dokku-mariadb-plugin)                                   | [dokku][]             | 0.3.25+               |
 | [Memcached (beta)](https://github.com/dokku/dokku-memcached-plugin)                               | [dokku][]             | 0.3.25+               |
+| [Mongo (beta)](https://github.com/dokku/dokku-mongo-plugin)                                       | [dokku][]             | 0.3.25+               |
 | [MySQL (beta)](https://github.com/dokku/dokku-mysql-plugin)                                       | [dokku][]             | 0.3.25+               |
 | [Postgres (beta)](https://github.com/dokku/dokku-redis-plugin)                                    | [dokku][]             | 0.3.25+               |
+| [RabbitMQ (beta)](https://github.com/dokku/dokku-rabbitmq-plugin)                                 | [dokku][]             | 0.3.25+               |
 | [Redis (beta)](https://github.com/dokku/dokku-redis-plugin)                                       | [dokku][]             | 0.3.25+               |
+| [RethinkDB (beta)](https://github.com/dokku/dokku-rethinkdb-plugin)                               | [dokku][]             | 0.3.25+               |
 
 ## Community plugins
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -31,7 +31,7 @@ The following plugins are available and provided by dokku maintainers. Where not
 | [Memcached (beta)](https://github.com/dokku/dokku-memcached-plugin)                               | [dokku][]             | 0.3.25+               |
 | [Mongo (beta)](https://github.com/dokku/dokku-mongo-plugin)                                       | [dokku][]             | 0.3.25+               |
 | [MySQL (beta)](https://github.com/dokku/dokku-mysql-plugin)                                       | [dokku][]             | 0.3.25+               |
-| [Postgres (beta)](https://github.com/dokku/dokku-redis-plugin)                                    | [dokku][]             | 0.3.25+               |
+| [Postgres (beta)](https://github.com/dokku/dokku-postgres-plugin)                                 | [dokku][]             | 0.3.25+               |
 | [RabbitMQ (beta)](https://github.com/dokku/dokku-rabbitmq-plugin)                                 | [dokku][]             | 0.3.25+               |
 | [Redis (beta)](https://github.com/dokku/dokku-redis-plugin)                                       | [dokku][]             | 0.3.25+               |
 | [RethinkDB (beta)](https://github.com/dokku/dokku-rethinkdb-plugin)                               | [dokku][]             | 0.3.25+               |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -20,6 +20,19 @@ dokku plugins-install
 
 [See the full documentation](http://progrium.viewdocs.io/dokku/development/plugin-creation).
 
+## Official Plugins (Beta)
+
+The following plugins are available and provided by dokku maintainers. Where noted, these plugins should be considered beta software and may not have been used as thoroughly as community plugins. Please file issues against their respective issue trackers.
+
+| Plugin                                                                                            | Author                | Compatibility         |
+| ------------------------------------------------------------------------------------------------- | --------------------- | --------------------- |
+| [Elasticsearch (beta)](https://github.com/dokku/dokku-elasticsearch-plugin)                       | [dokku][]             | 0.3.25+               |
+| [MariaDB (beta)](https://github.com/dokku/dokku-mariadb-plugin)                                   | [dokku][]             | 0.3.25+               |
+| [Memcached (beta)](https://github.com/dokku/dokku-memcached-plugin)                               | [dokku][]             | 0.3.25+               |
+| [MySQL (beta)](https://github.com/dokku/dokku-mysql-plugin)                                       | [dokku][]             | 0.3.25+               |
+| [Postgres (beta)](https://github.com/dokku/dokku-redis-plugin)                                    | [dokku][]             | 0.3.25+               |
+| [Redis (beta)](https://github.com/dokku/dokku-redis-plugin)                                       | [dokku][]             | 0.3.25+               |
+
 ## Community plugins
 
 Note: The following plugins have been supplied by our community and may not have been tested by dokku maintainers.
@@ -82,6 +95,7 @@ Note: The following plugins have been supplied by our community and may not have
 [Maciej Łebkowski]: https://github.com/mlebkowski
 [abossard]: https://github.com/dudagroup
 [alexkruegger]: https://github.com/alexkruegger
+[dokku]: https://github.com/dokku
 
 ### Datastores
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -26,15 +26,15 @@ The following plugins are available and provided by dokku maintainers. Where not
 
 | Plugin                                                                                            | Author                | Compatibility         |
 | ------------------------------------------------------------------------------------------------- | --------------------- | --------------------- |
-| [Elasticsearch (beta)](https://github.com/dokku/dokku-elasticsearch-plugin)                       | [dokku][]             | 0.3.25+               |
-| [MariaDB (beta)](https://github.com/dokku/dokku-mariadb-plugin)                                   | [dokku][]             | 0.3.25+               |
-| [Memcached (beta)](https://github.com/dokku/dokku-memcached-plugin)                               | [dokku][]             | 0.3.25+               |
-| [Mongo (beta)](https://github.com/dokku/dokku-mongo-plugin)                                       | [dokku][]             | 0.3.25+               |
-| [MySQL (beta)](https://github.com/dokku/dokku-mysql-plugin)                                       | [dokku][]             | 0.3.25+               |
-| [Postgres (beta)](https://github.com/dokku/dokku-postgres-plugin)                                 | [dokku][]             | 0.3.25+               |
-| [RabbitMQ (beta)](https://github.com/dokku/dokku-rabbitmq-plugin)                                 | [dokku][]             | 0.3.25+               |
-| [Redis (beta)](https://github.com/dokku/dokku-redis-plugin)                                       | [dokku][]             | 0.3.25+               |
-| [RethinkDB (beta)](https://github.com/dokku/dokku-rethinkdb-plugin)                               | [dokku][]             | 0.3.25+               |
+| [Elasticsearch (beta)](https://github.com/dokku/dokku-elasticsearch-plugin)                       | [dokku][]             | 0.4.0+                |
+| [MariaDB (beta)](https://github.com/dokku/dokku-mariadb-plugin)                                   | [dokku][]             | 0.4.0+                |
+| [Memcached (beta)](https://github.com/dokku/dokku-memcached-plugin)                               | [dokku][]             | 0.4.0+                |
+| [Mongo (beta)](https://github.com/dokku/dokku-mongo-plugin)                                       | [dokku][]             | 0.4.0+                |
+| [MySQL (beta)](https://github.com/dokku/dokku-mysql-plugin)                                       | [dokku][]             | 0.4.0+                |
+| [Postgres (beta)](https://github.com/dokku/dokku-postgres-plugin)                                 | [dokku][]             | 0.4.0+                |
+| [RabbitMQ (beta)](https://github.com/dokku/dokku-rabbitmq-plugin)                                 | [dokku][]             | 0.4.0+                |
+| [Redis (beta)](https://github.com/dokku/dokku-redis-plugin)                                       | [dokku][]             | 0.4.0+                |
+| [RethinkDB (beta)](https://github.com/dokku/dokku-rethinkdb-plugin)                               | [dokku][]             | 0.4.0+                |
 
 ## Community plugins
 


### PR DESCRIPTION
Something that has been a long time coming, but here are official dokku datastores.

Note that all have been marked as beta (because they are!) and their implementations may change wildly. All plugins appear to work fine under docker 1.7. I plan on formalizing a release process for each, as well as guiding their development. 

All plugins use the official docker images, and I do not intend to change this. Their interface should stay the same, and in fact the diffs between each plugin should be quite minimal.

One thing I plan on noting in the documentation is that these datastores do not provide any sort of backup solution, and it is up to the developer to implement such a thing for their system (if their data is important enough).

All plugins roughly meet the spec proposed by @miraculixx in #854, with a few changes:

- Added a `service:unexpose` command, to remove any exposed ports.
- Added a `service:alias` command, which allows users to change the alias in use by a service.
- Changed `service:delete` to `service:destroy`, to match how the core works/
- Services store their data in `/var/lib/dokku/services/DATASTORE/SERVICE_NAME` instead of the home directory.
- Usage of the `docker-args` pluginhook instead of the `dokku:link` plugin, to reduce dependencies.

### Available datastore plugins

- [Elasticsearch](https://github.com/dokku/dokku-elasticsearch-plugin) [missing clone, connect, export, import]
- [MariaDB](https://github.com/dokku/dokku-mariadb-plugin)
- [Memcached](https://github.com/dokku/dokku-memcached-plugin) [missing clone, export, import]
- [Mongo](https://github.com/dokku/dokku-mongo-plugin)
- [MySQL](https://github.com/dokku/dokku-mysql-plugin)
- [Postgres](https://github.com/dokku/dokku-postgres-plugin)
- [RabbitMQ](https://github.com/dokku/dokku-rabbitmq-plugin) [missing clone, connect, export, import]
- [Redis](https://github.com/dokku/dokku-redis-plugin)
- [RethinkDB](https://github.com/dokku/dokku-rethinkdb-plugin) [missing clone, export, import]

### TODO:

- [x] Add [mongo](https://github.com/docker-library/docs/blob/master/mongo/README.md) plugin.
- [x] Add [rabbitmq](https://github.com/docker-library/docs/blob/master/rabbitmq/README.md) plugin.
- [x] Add [rethinkdb](https://github.com/docker-library/docs/blob/master/rethinkdb/README.md) plugin.
- [x] Finish implementation of `expose`/`unexpose`.
- [x] Ensure services come up on server reboot.
- [x] Document the services command structure and inner workings

Affexted existing datastore maintainers /cc @Kloadut @ohardy @hughfletcher @jlachowski @jeffutter @Flink @luxifer @sekjun9878 @robv @blag