### PR TITLE
Fix dokku ps <app> over ssh

### DIFF
--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -12,7 +12,8 @@ case "$1" in
     ! (is_deployed $APP) && echo "App $APP has not been deployed" && exit 0
 
     for CID in $CONTAINER_IDS; do
-      docker exec -ti "$CID" /bin/sh -c "ps auxwww"
+      has_tty && DOKKU_RUN_OPTS="-i -t"
+      docker exec $DOKKU_RUN_OPTS $CID /bin/sh -c "ps auxwww"
     done
   ;;
 


### PR DESCRIPTION
Corrects error dialog seen by new users attempting to use the shell's help:

dokku> dokku help
 !    `dokku help` is not a dokku command.
  !    See `dokku help` for a list of available commands.

Resolves the TTY error when connecting over ssh. Updated ps to use has_tty function.