### PR TITLE
Set `DYNO_TYPE_NUMBER` environment variable for each container

### DIFF
--- a/dokku
+++ b/dokku
@@ -92,6 +92,7 @@ case "$1" in
         # start the app
         DOCKER_ARGS=$(: | pluginhook docker-args $APP deploy)
         DOCKER_ARGS+=" -e DYNO=$PROC_TYPE "
+        DOCKER_ARGS+=" -e DYNO_TYPE_NUMBER=$PROC_TYPE.$CONTAINER_INDEX "
         DOCKER_ARGS+=$(: | pluginhook docker-args-deploy $APP)
         BIND_EXTERNAL=$(pluginhook bind-external-ip $APP)
 

--- a/dokku
+++ b/dokku
@@ -92,7 +92,7 @@ case "$1" in
         # start the app
         DOCKER_ARGS=$(: | pluginhook docker-args $APP deploy)
         DOCKER_ARGS+=" -e DYNO=$PROC_TYPE "
-        DOCKER_ARGS+=" -e DYNO_TYPE_NUMBER=$PROC_TYPE.$CONTAINER_INDEX "
+        DOCKER_ARGS+=" -e DYNO_TYPE_NUMBER='$PROC_TYPE.$CONTAINER_INDEX' "
         DOCKER_ARGS+=$(: | pluginhook docker-args-deploy $APP)
         BIND_EXTERNAL=$(pluginhook bind-external-ip $APP)
 


### PR DESCRIPTION
This will allow users to inspect the underlying environment and conditionally run different commands based upon the `DYNO_TYPE_NUMBER`. The values will be set in the following format:

````
web.1
web.2
worker.1
worker.2
clock.1
````

Users of process managing plugins and dockerfiles can check the `DYNO_TYPE_NUMBER` and set a specific command to run.

Closes #1350