### PR TITLE
Plugins management

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -16,7 +16,7 @@ case "$1" in
     sshcommand create dokku /usr/local/bin/dokku
     egrep -i "^docker" /etc/group || groupadd docker
     usermod -aG docker dokku
-    dokku plugins-install
+    dokku plugins-install --core
     rm -f /home/dokku/VERSION
     cp /var/lib/dokku/STABLE_VERSION /home/dokku/VERSION
 

--- a/dokku
+++ b/dokku
@@ -5,8 +5,11 @@ shopt -s nullglob
 export DOKKU_DISTRO=${DOKKU_DISTRO:="ubuntu"}
 export DOKKU_IMAGE=${DOKKU_IMAGE:="gliderlabs/herokuish"}
 export DOKKU_ROOT=${DOKKU_ROOT:=~dokku}
+export DOKKU_LIB_ROOT=${DOKKU_LIB_PATH:="/var/lib/dokku"}
 
-export PLUGIN_PATH=${PLUGIN_PATH:="/var/lib/dokku/plugins"}
+export PLUGIN_PATH=${PLUGIN_PATH:="$DOKKU_LIB_ROOT/plugins"}
+export PLUGIN_CORE_PATH=${PLUGIN_CORE_PATH:="$DOKKU_LIB_ROOT/core-plugins"}
+export PLUGIN_DISABLED_PATH=${PLUGIN_DISABLED_PATH:="$DOKKU_LIB_ROOT/disabled-plugins"}
 export DOKKU_NOT_IMPLEMENTED_EXIT=10
 export DOKKU_VALID_EXIT=0
 
@@ -196,19 +199,44 @@ case "$1" in
     ;;
 
   plugins)
-    ls -1 -d $PLUGIN_PATH/*/
+    for plugin in "$PLUGIN_PATH"/*/; do
+      basename "$plugin"
+    done
     ;;
 
   plugins-install)
+    if [[ $2 == "--core" ]]; then
+      export PLUGIN_PATH="$PLUGIN_CORE_PATH"
+    fi
     pluginhook install
     ;;
 
   plugins-install-dependencies)
+    if [[ $2 == "--core" ]]; then
+      export PLUGIN_PATH="$PLUGIN_CORE_PATH"
+    fi
     pluginhook dependencies
     ;;
 
   plugins-update)
     pluginhook update
+    ;;
+
+  plugins:disable)
+    PLUGIN="$2"
+    [[ -e $PLUGIN_CORE_PATH/$PLUGIN ]] && echo "Cannot disable a core plugin" && exit 1
+    [[ -e $PLUGIN_DISABLED_PATH/$PLUGIN ]] && echo "Plugin already disabled" && exit 1
+    [[ ! -e $PLUGIN_PATH/$PLUGIN ]] && echo "Plugin does not exist" && exit 1
+    mv "$PLUGIN_PATH/$PLUGIN" "$PLUGIN_DISABLED_PATH"
+    echo "Plugin $PLUGIN disabled"
+    ;;
+
+  plugins:enable)
+    PLUGIN="$2"
+    [[ -e $PLUGIN_PATH/$PLUGIN ]] && echo "Plugin already enabled" && exit 1
+    [[ ! -e $PLUGIN_DISABLED_PATH/$PLUGIN ]] && echo "Plugin does not exist" && exit 1
+    mv "$PLUGIN_DISABLED_PATH/$PLUGIN" "$PLUGIN_PATH"
+    echo "Plugin $PLUGIN enabled"
     ;;
 
   # DEPRECATED as of v0.3.14
@@ -225,8 +253,11 @@ case "$1" in
     cat<<EOF | pluginhook commands help | sort | column -c2 -t -s,
     help, Print the list of commands
     plugins, Print active plugins
-    plugins-install, Install active plugins
+    plugins-install [--core], Install active plugins (or only core ones)
+    plugins-install-dependencies [--core], Install active plugins dependencies (or only core ones)
     plugins-update, Update active plugins
+    plugins:enable <name>, Enable a previously disabled plugin
+    plugins:disable <name>, Disable an installed plugin (third-party only)
 EOF
     ;;
 


### PR DESCRIPTION
As discussed in https://github.com/progrium/dokku/issues/1205, I tried a way to manage plugins and be able to do a `dokku plugins-install` only on core ones.

This PR is here to discuss the features and the details of the implementation.

It’s pretty basic for now but it works as intended :)
So we have three subdirectories in `/var/lib/dokku/plugins`, `core`, `custom` and `enabled`. Plugins are now divided in two categories: core ones and other ones.
The `enabled` directory only links to plugins (either in `core` or `enabled` directories). The core plugins are enabled automatically when installing dokku and cannot be disabled.

There are two new commands:
* `dokku plugins:enable <name>` to enable a third party plugin.
* `dokku plugins:disable <name>` to disable a third party plugin. Core plugins cannot be disabled by this command.

`plugins-install` and `plugins-install-dependencies` now take an optional argument `--core` which when set will instruct those commands to only refer to the core plugins. This should resolve the issue #1205.
This happens by setting PLUGIN_PATH to `/var/lib/dokku/plugins/core` instead of the default `/var/lib/dokku/plugins/enabled` when `--core` is set.

/cc @josegonzalez @michaelshobbs @jimeh