### PR TITLE
Use `$PLUGIN_PATH` instead of `$(dirname $0)/..`

### DIFF
--- a/docs/development/plugin-creation.md
+++ b/docs/development/plugin-creation.md
@@ -15,7 +15,7 @@ The below plugin is a dummy `dokku hello` plugin. If your plugin exposes command
 ```shell
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 case "$1" in
   hello)

--- a/docs/development/pluginhooks.md
+++ b/docs/development/pluginhooks.md
@@ -253,7 +253,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 dokku_log_info1" Installing GraphicsMagick..."
 
@@ -279,7 +279,7 @@ docker commit $ID $IMAGE > /dev/null
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 dokku_log_info1" Installing $CONTAINER_PACKAGE..."
 
@@ -360,7 +360,7 @@ fi
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 APP="$1"
 IMAGE="dokku/$APP"

--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 case "$1" in
   build)

--- a/plugins/20_events/commands
+++ b/plugins/20_events/commands
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 PLUGIN_DIR="$(dirname $0)"
 

--- a/plugins/20_events/hook
+++ b/plugins/20_events/hook
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 [[ ! "$DOKKU_EVENTS" ]] || dokku_log_pluginhook_call "$(basename $0)" "$@"

--- a/plugins/20_events/install
+++ b/plugins/20_events/install
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 DOKKU_RSYSLOG_FILTER=/etc/rsyslog.d/99-dokku.conf
 DOKKU_LOGROTATE_FILE=/etc/logrotate.d/dokku

--- a/plugins/apps/commands
+++ b/plugins/apps/commands
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 case "$1" in
   apps)

--- a/plugins/build-env/pre-build
+++ b/plugins/build-env/pre-build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 APP="$1"; IMAGE="dokku/$APP"; BUILD_ENV=""
 

--- a/plugins/checks/check-deploy
+++ b/plugins/checks/check-deploy
@@ -35,7 +35,7 @@
 #
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 APP="$1"; DOKKU_APP_CONTAINER_ID="$2"; DOKKU_APP_CONTAINER_TYPE="$3"; DOKKU_APP_LISTEN_PORT="$4"; DOKKU_APP_LISTEN_IP="$5"
 if [[ -z "$DOKKU_APP_LISTEN_PORT" ]] && [[ -f "$DOKKU_ROOT/$APP/PORT" ]]; then

--- a/plugins/config/commands
+++ b/plugins/config/commands
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 config_create () {
   [ -f $ENV_FILE ] || {

--- a/plugins/config/docker-args-deploy
+++ b/plugins/config/docker-args-deploy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 STDIN=$(cat); APP="$1"; IMAGE="dokku/$APP"
 DOCKERFILE_ENV_FILE="$DOKKU_ROOT/$APP/DOCKERFILE_ENV_FILE"

--- a/plugins/docker-options/commands
+++ b/plugins/docker-options/commands
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 PHASES=(build deploy run)
 

--- a/plugins/domains/commands
+++ b/plugins/domains/commands
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 RE_IPV4="([0-9]{1,3}[\.]){3}[0-9]{1,3}"
 

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 git_build_app_repo() {
   verify_app_name "$1"

--- a/plugins/git/receive-app
+++ b/plugins/git/receive-app
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 APP="$1"; REV="$2"
 

--- a/plugins/nginx-vhosts/commands
+++ b/plugins/nginx-vhosts/commands
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 validate_nginx () {
   set +e

--- a/plugins/nginx-vhosts/post-deploy
+++ b/plugins/nginx-vhosts/post-deploy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 APP="$1"
 if [[ -f "$DOKKU_ROOT/$APP/IP.web.1" ]] && [[ -f "$DOKKU_ROOT/$APP/PORT.web.1" ]]; then

--- a/plugins/nginx-vhosts/post-domains-update
+++ b/plugins/nginx-vhosts/post-domains-update
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 APP="$1"
 

--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 source "$(dirname $0)/functions"
 
 case "$1" in

--- a/plugins/ps/functions
+++ b/plugins/ps/functions
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 
 release_and_deploy() {
-  source "$(dirname $0)/../common/functions"
+  source "$PLUGIN_PATH/common/functions"
   local APP="$1"; local IMAGE="dokku/$APP"
 
   if verify_image "$IMAGE"; then

--- a/plugins/ps/pre-deploy
+++ b/plugins/ps/pre-deploy
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-source "$(dirname $0)/../common/functions"
+source "$PLUGIN_PATH/common/functions"
 source "$(dirname $0)/functions"
 
 APP="$1"


### PR DESCRIPTION
As briefly discussed in #1425, source the `common/functions` file via an absolute path, rather than determining the relative path by using `dirname`. 3rd-party plugins should follow suit and use the new `$PLUGIN_PATH` convention too.

I only had a few minutes of spare time to put this together, so I haven't run tests locally, and instead will be relying on the PR CI stuff to do it for me :)