### PR TITLE
Changed BOX_NAME to bento/ubuntu-14.04 [ci skip]

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-BOX_NAME = ENV["BOX_NAME"] || "chef/ubuntu-14.04"
+BOX_NAME = ENV["BOX_NAME"] || "bento/ubuntu-14.04"
 BOX_MEMORY = ENV["BOX_MEMORY"] || "1024"
 DOKKU_DOMAIN = ENV["DOKKU_DOMAIN"] || "dokku.me"
 DOKKU_IP = ENV["DOKKU_IP"] || "10.0.0.2"


### PR DESCRIPTION
`vagrant up` on master errors out with `The box 'chef/ubuntu-14.04' could not be found`.

Chef appears to have moved their boxes to the "bento" org
https://atlas.hashicorp.com/bento/