### PR TITLE
Add helper function for inspecting the state of a container

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -233,6 +233,18 @@ is_container_running () {
   fi
 }
 
+is_container_status () {
+  local CID=$1
+  local TEMPLATE="{{.State.$2}}"
+  local CONTAINER_STATUS=$(docker inspect -f "$TEMPLATE" "$CID" || true)
+
+  if [[ "$CONTAINER_STATUS" == "true" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 is_app_running() {
   local APP="$1"
   verify_app_name $APP


### PR DESCRIPTION
This function - `is_container_status` - can be used to inspect whether a container is any of the following:

- Dead
- OOMKilled
- Paused
- Restarting
- Running

It can be useful for deeper inspection as to plugin state.