### PR TITLE
Revert change that whitelisted dokku-labeled containers

### DIFF
--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -323,12 +323,8 @@ release_and_deploy() {
 
 docker_cleanup() {
   # delete all non-running containers
-  # if a container has the label `dokku.service`,
-  # then that container is not deleted.
-  # This can be used to mark data containers
-  # as non-removable by the cleanup function
   # shellcheck disable=SC2046
-  docker rm $(comm <(docker ps -aq -f 'status=exited' | sort) <(docker ps -aq -f 'status=exited' -f 'label=dokku.service' | sort) -3) &> /dev/null || true
+  docker rm $(docker ps -a -f 'status=exited' -q) &> /dev/null || true
   # delete unused images
   # shellcheck disable=SC2046
   docker rmi $(docker images -f 'dangling=true' -q) &> /dev/null &


### PR DESCRIPTION
Rather than having a one-off hack for "blessed" containers, we should solve the issue properly. As that would take a bit more work, reverting to the previous state is preferred.

Better that we solve a problem problem than with a hack that we'll need to roll back in the future.

Refs #1220