### PR TITLE
idea: not requiring image-extras

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -46,7 +46,9 @@ dokku_install_package() {
   curl -sSL https://packagecloud.io/gpg.key | apt-key add -
 
   apt-get update > /dev/null
-  apt-get install -qq -y "linux-image-extra-$(uname -r)" apt-transport-https
+  
+  # if linux-image-extra isn't found for AUFS, allow it to continue and use devicemapper.
+  apt-get install -qq -y "linux-image-extra-$(uname -r)" apt-transport-https || true
 
   echo "deb https://get.docker.io/ubuntu docker main" > /etc/apt/sources.list.d/docker.list
   echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ trusty main" > /etc/apt/sources.list.d/dokku.list


### PR DESCRIPTION
This is more of a thought experiment.

But adding `|| true` to the line that attempts to install `linux-image-extra-...` would mean that dokku could run places with custom kernels, like Linode, by falling back to DeviceMapper. People who really want AUFS could use pv-grub and the StackScript (once a documentation tweak is made).

Is that just a crazy idea? I know that DeviceMapper has worse performance for starting/stopping containers, but as AUFS isn't upstream, it seems like it might work