### PR TITLE
limit amount of lines in "dokku logs -t"

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -151,7 +151,7 @@ case "$1" in
       LAST_CONTAINER_ID=${CONTAINER_IDS[${#CONTAINER_IDS[@]} - 1]}
 
       if [[ $3 == "-t" ]]; then
-        DOKKU_LOGS_ARGS="--follow"
+        DOKKU_LOGS_ARGS="--follow --tail 100"
       else
         DOKKU_LOGS_ARGS="--tail 100"
       fi


### PR DESCRIPTION
Long running applications are producing enormous amount of logs and currently "dokku logs -t" throws all history from proccess start to console.

This patch limits amounts of log lines to 100, as in "dokku logs" without -t