### PR TITLE
Move plugins into proper directory for deb packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ stack.tgz
 build
 tmp
 *.deb
+.ruby-version

--- a/deb.mk
+++ b/deb.mk
@@ -86,13 +86,13 @@ deb-dokku: deb-setup
 
 	cp -r debian /tmp/build/DEBIAN
 	mkdir -p /tmp/build/usr/local/bin
-	mkdir -p /tmp/build/var/lib/dokku
+	mkdir -p /tmp/build/var/lib/dokku/core-plugins/available
 	mkdir -p /tmp/build/usr/local/share/man/man1
 	mkdir -p /tmp/build/usr/local/share/dokku/contrib
 
 	cp dokku /tmp/build/usr/local/bin
-	cp -r plugins /tmp/build/var/lib/dokku
-	find plugins/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read plugin; do touch /tmp/build/var/lib/dokku/plugins/$$plugin/.core; done
+	cp -r plugins/* /tmp/build/var/lib/dokku/core-plugins/available
+	find plugins/ -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | while read plugin; do touch /tmp/build/var/lib/dokku/core-plugins/available/$$plugin/.core; done
 	$(MAKE) help2man
 	$(MAKE) addman
 	cp /usr/local/share/man/man1/dokku.1 /tmp/build/usr/local/share/man/man1/dokku.1


### PR DESCRIPTION
Fixes the broken 0.4.0 package. Yay core-plugins!