### PR TITLE
do not use exit 0 in config functions

### DIFF
--- a/plugins/build-env/pre-build-buildpack
+++ b/plugins/build-env/pre-build-buildpack
@@ -6,8 +6,8 @@ source "$PLUGIN_AVAILABLE_PATH/config/functions"
 APP="$1"; IMAGE=$(get_app_image_name $APP); BUILD_ENV=""
 verify_app_name "$APP"
 
-config_get --global CURL_CONNECT_TIMEOUT > /dev/null 2>&1 || config_set --global CURL_CONNECT_TIMEOUT=5
-config_get --global CURL_TIMEOUT > /dev/null 2>&1 || config_set --global CURL_TIMEOUT=30
+[[ -z $(config_get --global CURL_CONNECT_TIMEOUT) ]] && config_set --global CURL_CONNECT_TIMEOUT=5
+[[ -z $(config_get --global CURL_TIMEOUT) ]] && config_set --global CURL_TIMEOUT=30
 
 if [[ -n $(config_export global) ]]; then
   BUILD_ENV+=$'\n'

--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -102,7 +102,7 @@ config_all() {
   [[ "$1" == "config" ]] || set -- "config" "$@"
   config_parse_args "$@"
   config_create "$ENV_FILE"
-  is_config_export "$@" && config_export "$DOKKU_CONFIG_TYPE" "$APP" && exit 0
+  is_config_export "$@" && config_export "$DOKKU_CONFIG_TYPE" "$APP" && return 0
 
   [[ "$APP" ]] && DOKKU_CONFIG_TYPE=$APP
   [[ ! -s $ENV_FILE ]] && dokku_log_fail "no config vars for $DOKKU_CONFIG_TYPE"
@@ -112,7 +112,7 @@ config_all() {
   for var in "$@"; do
     if [[ "$var" == "--shell" ]]; then
       echo $VARS
-      exit 0
+      return 0
     fi
   done
 
@@ -132,7 +132,7 @@ config_get() {
 
   config_create "$ENV_FILE"
   if [[ ! -s $ENV_FILE ]]; then
-    exit 0
+    return 0
   fi
 
   KEY="$3"

--- a/tests/unit/build-env.bats
+++ b/tests/unit/build-env.bats
@@ -15,16 +15,41 @@ teardown() {
   echo "output: "$output
   echo "status: "$status
   assert_success
+
   deploy_app
   run dokku config $TEST_APP
   assert_success
 }
 
-@test "(build-env) failure" {
+@test "(build-env) default curl timeouts" {
+  run dokku config:unset --global CURL_CONNECT_TIMEOUT
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run dokku config:unset --global CURL_TIMEOUT
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  deploy_app
+  run /bin/bash -c "dokku config:get --global CURL_CONNECT_TIMEOUT | grep 5"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+
+  run /bin/bash -c "dokku config:get --global CURL_TIMEOUT | grep 30"
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+}
+
+@test "(build-env) buildpack failure" {
   run dokku config:set --no-restart $TEST_APP BUILDPACK_URL='https://github.com/dokku/fake-buildpack'
   echo "output: "$output
   echo "status: "$status
   assert_success
+
   run deploy_app
   echo "output: "$output
   echo "status: "$status

--- a/tests/unit/build-env.bats
+++ b/tests/unit/build-env.bats
@@ -11,11 +11,22 @@ teardown() {
 }
 
 @test "(build-env) special characters" {
-  run dokku config:set $TEST_APP NEWRELIC_APP_NAME="$TEST_APP (Staging)"
+  run dokku config:set --no-restart $TEST_APP NEWRELIC_APP_NAME="$TEST_APP (Staging)"
   echo "output: "$output
   echo "status: "$status
   assert_success
   deploy_app
   run dokku config $TEST_APP
   assert_success
+}
+
+@test "(build-env) failure" {
+  run dokku config:set --no-restart $TEST_APP BUILDPACK_URL='https://github.com/dokku/fake-buildpack'
+  echo "output: "$output
+  echo "status: "$status
+  assert_success
+  run deploy_app
+  echo "output: "$output
+  echo "status: "$status
+  assert_failure
 }


### PR DESCRIPTION
using `exit 0` in the config functions broke the build-env plugin by exiting before populating `$BUILD_ENV`
also revealed that our build-env test coverage sucked

this fixes both AND adds a test

`CURL_TIMEOUT` defaults were broken as well. added tests.
