### PR TITLE
make sure applications stop (and start) when using ps:restart

### DIFF
--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -70,7 +70,10 @@ case "$1" in
 
     ! (is_deployed $APP) && echo "App $APP has not been deployed" && exit 0
 
-    release_and_deploy "$APP" "$IMAGE_TAG"
+    if (is_app_running $APP); then
+        dokku ps:stop "$APP"
+    fi
+    dokku ps:start "$APP"
     ;;
 
   ps:restartall)


### PR DESCRIPTION
As noted in #1505, `dokku ps:restart` does not actually stop existing docker instances. This can be seen by running `docker ps` before and `docker ps` after `dokku ps:restart`. This same behavior happens upon restarting the system as `dokku ps:restartall` is run upon boot. This can lead to numerous 'zombie' docker processes.

This change solves the problem for me. It now runs `dokku ps:stop` and `dokku ps:start` when running `docker ps:restart`. Before this change `release_and_deploy` was run, which is what `dokku ps:start` does as well, but whichout checking whether the app was already running.