### PR TITLE
corrected README.md's ref to bootstrap.sh URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker powered mini-Heroku. The smallest PaaS implementation you've ever seen. S
 
 To install the latest stable release, you can run the following commands as a user that has access to `sudo`:
 
-    wget https://raw.githubusercontent.com/progrium/dokku/master/bootstrap.sh
+    wget https://raw.githubusercontent.com/progrium/dokku/v0.4.1/bootstrap.sh
     sudo DOKKU_TAG=v0.4.1 bash bootstrap.sh
 
 ### Upgrading

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Docker powered mini-Heroku. The smallest PaaS implementation you've ever seen. S
 
 To install the latest stable release, you can run the following commands as a user that has access to `sudo`:
 
-    wget https://raw.github.com/progrium/dokku/v0.4.1/bootstrap.sh
+    wget https://raw.githubusercontent.com/progrium/dokku/master/bootstrap.sh
     sudo DOKKU_TAG=v0.4.1 bash bootstrap.sh
 
 ### Upgrading


### PR DESCRIPTION
The URL w/ raw.github.com wasn't working for me, clicking the raw link in GH's repo led me [https://raw.githubusercontent.com/progrium/dokku/master/bootstrap.sh](https://raw.githubusercontent.com/progrium/dokku/master/bootstrap.sh), which is working; so I updated the URL.