### PR TITLE
Make room for the longer URL from #1522

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -41,7 +41,7 @@ h1 {
   font-size: 12px;
   line-height: 1.3em;
   margin: 45px auto;
-  max-width: 650px;
+  max-width: 750px;
   padding: 0;
 }
 .quickstart-code .title {


### PR DESCRIPTION
Since #1522, the URL is now too long to fit inside our `max-width: 650px` box. This bumps the box to `750px` which fits the current URL.

Before:

![before](https://cloud.githubusercontent.com/assets/24193/10239803/06d4d3cc-6899-11e5-838d-38b7f518bbd9.png)

After:

![after](https://cloud.githubusercontent.com/assets/24193/10239804/0b00316c-6899-11e5-95a7-0d27874fa52c.png)
