### PR TITLE
Adds helpful information regarding whitespacing when setting config

### DIFF
--- a/plugins/config/functions
+++ b/plugins/config/functions
@@ -147,6 +147,7 @@ config_set() {
 
   if [[ -z "${*:3}" ]]; then
     echo "Usage: dokku config:set APP KEY1=VALUE1 [KEY2=VALUE2 ...]"
+    echo "Whitespaces need to be escaped, i.e. KEY=\"VAL\ WITH\ SPACES\""
     echo "Must specify KEY and VALUE to set."
     exit 1
   fi
@@ -160,6 +161,7 @@ config_set() {
   for var; do
     if [[ $var != *"="* ]]; then
       echo "Usage: dokku config:set APP KEY1=VALUE1 [KEY2=VALUE2 ...]"
+      echo "Whitespaces need to be escaped, i.e. KEY=\"VAL\ WITH\ SPACES\""
       echo "Must specify KEY and VALUE to set."
       exit 1
     fi


### PR DESCRIPTION
I found this issue https://github.com/progrium/dokku/issues/1361 where users were unable to set their keys unless the whitespacing was escaped, and the first step suggested in the issue was to update the help output, as to give users more helpful information about how to get their values in correctly. I've done that in this PR, to hopefully help the next person along the way. I believe this was supposed to be pointing to the master branch, based on the contributing guidelines. Please let me know if there is anything I can do to improve this contribution. Looking forward to hearing back from you!