### PR TITLE
Add docker-engine-cs as docker-engine alternative

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Version: 0.3.12
 Section: base
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, software-properties-common, docker-engine | lxc-docker, gcc, python-software-properties, man-db, herokuish, sshcommand
+Depends: locales, git, make, curl, software-properties-common, docker-engine | docker-engine-cs | lxc-docker, gcc, python-software-properties, man-db, herokuish, sshcommand
 Pre-Depends: nginx, dnsutils, ruby, ruby-dev, rubygem-rack, rubygem-rack-protection, rubygem-sinatra, rubygem-tilt, apparmor, cgroupfs-mount | cgroup-lite, plugn
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 Description: Docker powered mini-Heroku in around 100 lines of Bash


### PR DESCRIPTION
docker-engine-cs is the commercially supported version of docker, and therefore should be fully compatible.