### PR TITLE
README: Switch to CURL from wget on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Docker powered mini-Heroku. The smallest PaaS implementation you've ever seen. S
 
 To install the latest stable release, you can run the following commands as a user that has access to `sudo`:
 
-    wget https://raw.githubusercontent.com/progrium/dokku/v0.4.2/bootstrap.sh
-    sudo DOKKU_TAG=v0.4.2 bash bootstrap.sh
+    curl https://raw.githubusercontent.com/progrium/dokku/v0.4.2/bootstrap.sh | DOKKU_TAG=v0.4.2 bash
 
 ### Upgrading
 


### PR DESCRIPTION
dokku already requires curl for installation so it is better to use curl to download the bootstrap script as well.