### PR TITLE
make sure dokku can read nginx logs and don't remove other perms

### DIFF
--- a/dokku
+++ b/dokku
@@ -41,7 +41,7 @@ if [[ "${args[0]}" =~ ^--.* ]]; then
 fi
 ! has_tty && DOKKU_QUIET_OUTPUT=1
 
-if [[ $(id -un) != "dokku" && $1 != plugin:*install* && $1 != "plugin:update" && $1 != nginx:*-logs ]]; then
+if [[ $(id -un) != "dokku" && $1 != plugin:*install* && $1 != "plugin:update" ]]; then
   sudo -u dokku -E -H $0 "$@"
   exit
 fi

--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -32,6 +32,11 @@ fi
 
 echo 'server_names_hash_bucket_size 512;' >| /etc/nginx/conf.d/server_names_hash_bucket_size.conf
 
+# make sure dokku can read the default log dir
+gpasswd -M "$(egrep ^adm /etc/group | awk -F ":" '{ print $4 }')" dokku
+chgrp -R dokku /var/log/nginx
+chmod g+r /var/log/nginx
+
 case "$DOKKU_DISTRO" in
   ubuntu)
     /etc/init.d/nginx start


### PR DESCRIPTION
- add current members of `adm` group to dokku group
- change group of `/var/log/nginx` (recursively) to `dokku`
- add group readable perm to everything in `/var/log/nginx`
- removes the check to bypass running `nginx:*-logs` commands as dokku 

closes #1572