### PR TITLE
Revert "Fix URLs for docu/ links"

### DIFF
--- a/docs/application-deployment.md
+++ b/docs/application-deployment.md
@@ -18,7 +18,7 @@ dokku apps:create ruby-rails-sample
 
 ### Create the backing services
 
-When you create a new app, Dokku by default *does not* provide any datastores such as mysql or postgres. You will need to install plugins to handle that, but fortunately [dokku has official plugins](/docs/plugins.md#official-plugins-beta) for common datastores. Our sample app requires a Postgres service:
+When you create a new app, Dokku by default *does not* provide any datastores such as mysql or postgres. You will need to install plugins to handle that, but fortunately [dokku has official plugins](/dokku/plugins/#official-plugins-beta) for common datastores. Our sample app requires a Postgres service:
 
 ```shell
 # install the postgres plugin
@@ -114,7 +114,7 @@ cat ~/.ssh/id_rsa.pub | ssh root@dokku.com "sudo sshcommand acl-add dokku [descr
 
 Dokku only supports deploying from its master branch, so if you'd like to deploy a different local branch use: ```git push dokku <local branch>:master```
 
-You can also support pushing multiple branches using the [receive-branch](/docs/development/plugin-triggers.md#receive-branch) plugin trigger in a custom plugin.
+You can also support pushing multiple branches using the [receive-branch](/dokku/development/plugin-triggers/#receive-branch) plugin trigger in a custom plugin.
 
 ### Deploying with private git submodules
 
@@ -180,16 +180,16 @@ Dokku is, at it's core, a docker container manager. Thus, it does not necessaril
 
 ## Default vhost
 
-See the [nginx documentation](/docs/nginx.md#default-site).
+See the [nginx documentation](/dokku/nginx/#default-site).
 
 ## Dockerfile deployment
 
-See the [dockerfile documentation](/docs/deployment/dockerfiles.md).
+See the [dockerfile documentation](/dokku/deployment/dockerfiles/).
 
 ## Zero downtime deploy
 
-See the [zero-downtime deploy documentation](/docs/checks-examples.md).
+See the [zero-downtime deploy documentation](/dokku/checks-examples/).
 
 ## Image tagging
 
-See the [image tagging documentation](/docs/deployment/images.md).
+See the [image tagging documentation](/dokku/deployment/images).

--- a/docs/deployment/dockerfiles.md
+++ b/docs/deployment/dockerfiles.md
@@ -18,7 +18,7 @@ By default, Dokku will extract the first `EXPOSE` tcp port and use said port wit
 dokku config:set APP DOKKU_DOCKERFILE_PORT=8000
 ```
 
-Dokku will not expose other ports on your application without a [custom docker-option](/docs/docker-options.md).
+Dokku will not expose other ports on your application without a [custom docker-option](/dokku/configuration/docker-options/).
 
 If you do not have a port explicitly exposed, Dokku will automatically expose port `5000` for your application.
 

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -199,12 +199,12 @@ Alternatively, you may push an app to your dokku host with a name like "00-defau
 
 ## Running behind a load balancer
 
-See the [load balancer documentation](/docs/deployment/ssl-configuration.md#running-behind-a-load-balancer).
+See the [load balancer documentation](/dokku/deployment/ssl-configuration/#running-behind-a-load-balancer).
 
 ## HSTS Header
 
-See the [HSTS documentation](/docs/deployment/ssl-configuration.md#hsts-header).
+See the [HSTS documentation](/dokku/deployment/ssl-configuration/#hsts-header).
 
 ## SSL Configuration
 
-See the [ssl documentation](/docs/deployment/ssl-configuration.md).
+See the [ssl documentation](/dokku/deployment/ssl-configuration/).

--- a/docs/remote-commands.md
+++ b/docs/remote-commands.md
@@ -25,4 +25,4 @@ in order to avoid ssh interpretting dokku arguments for itself.
 
 You may optionally use a client to connect to your dokku server. Most clients use the configured `git remote` to locate the dokku server, though some allow for overriding this via an environment variable or flag.
 
-Please refer to the [clients](/docs/community/clients.md) list for more details.
+Please refer to the [clients](/dokku/community/clients/) list for more details.


### PR DESCRIPTION
Reverts progrium/dokku#1583

The documentation is meant to be browsed from http://progrium.viewdocs.io/dokku/, not from github, hence the url changes. This is an issue with viewdocs, not something we can necessarily fix.