### PR TITLE
Added nginx SSL configuration to prevent POODLE attack on new installs.

### DIFF
--- a/plugins/nginx-vhosts/install
+++ b/plugins/nginx-vhosts/install
@@ -25,6 +25,8 @@ ssl_session_timeout 10m;
 
 ssl_ciphers EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
 
+ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # omit SSLv3 because of POODLE (CVE-2014-3566)
+
 # ssl_certificate $DOKKU_ROOT/tls/server.crt;
 # ssl_certificate_key $DOKKU_ROOT/tls/server.key;
 EOF


### PR DESCRIPTION
Hi folks!  I am not a super expert at this stuff, but I do what I can.  I ran https://www.ssllabs.com/ssltest/analyze.html against my new Dokku install from today, and saw that it needed an extra line of configuration to prevent the POODLE attack.

I made a quick branch (https://github.com/adamwolf/dokku/tree/POODLE) on my fork and it seems to pass, but I am not sure how you want to test it, upgrade existing installs/warn users... I am not a dokku expert either.

Thanks for dokku--it looks awesome.