### PR TITLE
Add missing bootstrap.sh step

### DIFF
--- a/docs/getting-started/install/debian.md
+++ b/docs/getting-started/install/debian.md
@@ -15,6 +15,7 @@ curl -sSL https://packagecloud.io/gpg.key | apt-key add -
 echo "deb https://packagecloud.io/dokku/dokku/ubuntu/ trusty main" | sudo tee /etc/apt/sources.list.d/dokku.list
 sudo apt-get update -qq > /dev/null
 sudo apt-get install dokku
+sudo dokku plugin:install-dependencies --core
 ```
 
 ## Unattended installation


### PR DESCRIPTION
The debian/non-bootstrap.sh instructions were missing the plugin dependencies installer step.