### PR TITLE
Resolve SC2115: 'Use "${var:?}" to ensure this never expands to /'

### DIFF
--- a/plugins/apps/post-delete
+++ b/plugins/apps/post-delete
@@ -3,7 +3,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_CORE_AVAILABLE_PATH/common/functions"
 
 APP="$1"; IMAGE_REPO=$(get_app_image_repo $APP)
-[[ -n $APP ]] && rm -rf "$DOKKU_ROOT/$APP" > /dev/null
+[[ -n $APP ]] && rm -rf "${DOKKU_ROOT:?}/$APP" > /dev/null
 
 # remove all application containers & images
 # shellcheck disable=SC2046


### PR DESCRIPTION
https://github.com/koalaman/shellcheck/wiki/SC2115