### PR TITLE
Resolve SC2029: 'this expands on client side'

### DIFF
--- a/contrib/dokku_client.sh
+++ b/contrib/dokku_client.sh
@@ -93,6 +93,7 @@ if [[ ! -z $DOKKU_HOST ]]; then
     fi
 
     if [[ -z "$donotshift" ]]; then
+      # shellcheck disable=SC2029
       ssh -o LogLevel=QUIET -t "dokku@$DOKKU_HOST" "$@"
       exit $?
     fi
@@ -119,7 +120,7 @@ if [[ ! -z $DOKKU_HOST ]]; then
         done
       fi
     fi
-    # shellcheck disable=SC2086
+    # shellcheck disable=SC2086,SC2029
     ssh -o LogLevel=QUIET -t "dokku@$DOKKU_HOST" $long_args "$verb" "$appname" "${args[@]}"
   }
 

--- a/tests.mk
+++ b/tests.mk
@@ -64,7 +64,7 @@ lint:
 	# SC2143: Instead of [ -n $(foo | grep bar) ], use foo | grep -q bar - https://github.com/koalaman/shellcheck/wiki/SC2143
 	# SC2001: See if you can use ${variable//search/replace} instead. - https://github.com/koalaman/shellcheck/wiki/SC2001
 	@echo linting...
-	@$(QUIET) shellcheck -e SC2029 ./contrib/dokku_client.sh
+	@$(QUIET) shellcheck ./contrib/dokku_client.sh
 	@$(QUIET) find . -not -path '*/\.*' | xargs file | egrep "shell|bash" | egrep -v "directory|toml" | awk '{ print $$1 }' | sed 's/://g' | grep -v dokku_client.sh | xargs shellcheck -e SC2034,SC2086,SC2143,SC2001
 
 unit-tests:


### PR DESCRIPTION
https://github.com/koalaman/shellcheck/wiki/SC2029

This patch addes inline directives where this is the desired behavior,
instead of globaly excluding the check.