### PR TITLE
Resolve SC2143: 'Instead of [ -n $(foo | grep bar) ], use foo | grep -q bar'

### DIFF
--- a/tests.mk
+++ b/tests.mk
@@ -61,11 +61,10 @@ lint:
 	# these are disabled due to their expansive existence in the codebase. we should clean it up though
 	# SC2034: VAR appears unused - https://github.com/koalaman/shellcheck/wiki/SC2034
 	# SC2086: Double quote to prevent globbing and word splitting - https://github.com/koalaman/shellcheck/wiki/SC2086
-	# SC2143: Instead of [ -n $(foo | grep bar) ], use foo | grep -q bar - https://github.com/koalaman/shellcheck/wiki/SC2143
 	# SC2001: See if you can use ${variable//search/replace} instead. - https://github.com/koalaman/shellcheck/wiki/SC2001
 	@echo linting...
 	@$(QUIET) shellcheck ./contrib/dokku_client.sh
-	@$(QUIET) find . -not -path '*/\.*' | xargs file | egrep "shell|bash" | egrep -v "directory|toml" | awk '{ print $$1 }' | sed 's/://g' | grep -v dokku_client.sh | xargs shellcheck -e SC2034,SC2086,SC2143,SC2001
+	@$(QUIET) find . -not -path '*/\.*' | xargs file | egrep "shell|bash" | egrep -v "directory|toml" | awk '{ print $$1 }' | sed 's/://g' | grep -v dokku_client.sh | xargs shellcheck -e SC2034,SC2086,SC2001
 
 unit-tests:
 	@echo running unit tests...


### PR DESCRIPTION
...we actually don't violate this

https://github.com/koalaman/shellcheck/wiki/SC2143