### PR TITLE
Fixup debian/control for Debian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,12 @@
 Package: dokku
-Version: 0.3.12
-Section: base
+Version: 0.4.3
+Section: web
 Priority: optional
 Architecture: amd64
-Depends: locales, git, make, curl, software-properties-common, docker-engine | docker-engine-cs | lxc-docker, gcc, python-software-properties, man-db, herokuish, sshcommand
-Pre-Depends: nginx, dnsutils, ruby, ruby-dev, rubygem-rack, rubygem-rack-protection, rubygem-sinatra, rubygem-tilt, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo
+Depends: locales, git, make, curl, gcc, man-db, herokuish, sshcommand,
+ docker-engine-cs | docker-engine | lxc-docker (>= 1.6.2) | docker.io (>= 1.6.2),
+ software-properties-common, python-software-properties
+Pre-Depends: nginx (>= 1.4.6), dnsutils, apparmor, cgroupfs-mount | cgroup-lite, plugn, sudo,
+ ruby, ruby-dev, rubygem-rack , rubygem-rack-protection, rubygem-sinatra, rubygem-tilt
 Maintainer: Jose Diaz-Gonzalez <dokku@josediazgonzalez.com>
 Description: Docker powered mini-Heroku in around 100 lines of Bash

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -10,6 +10,7 @@ To propose a release, the following tasks need to be performed:
 - The installable version must be changed in the `README.md` file.
 - The installable version must be changed in the `contrib/dokku-installer.rb` file.
 - The installable version must be changed in the `docs/template.html` file.
+- The installable version must be changed in the `debian/control` file.
 - The embedded css should be cleared in the `docs/template.html` file.
 - The versioned links should be updated in the `docs/home.html` file.
 - The versioned links should be updated in the `docs/template.html` file.


### PR DESCRIPTION
* Bump `Version` field.
* Set minimum nginx version to 1.4.6, per #1654
* Depend on both `rubygem-foo` (Ubuntu) and `ruby-foo` (Debian).
* Drop defunct `lxc-docker` package name
* Add distro-default `docker.io (>= 1.6.2)` as an alternative.

  Version 1.6.2 is in both `trusty-updates` and `jessie-backports`,
  while `trusty` itself has `0.9.1`. We seriously want to avoid that.

This also updates the docs so people don't forget to bump the version
field in the future.