### PR TITLE
add $REV to pre-receive-app call

### DIFF
--- a/docs/development/plugin-triggers.md
+++ b/docs/development/plugin-triggers.md
@@ -610,7 +610,7 @@ nginx -t
 
 - Description: Allows you to customize the contents of an application directory before they are processed for deployment. The `IMAGE_SOURCE_TYPE` can be any of `[herokuish, dockerfile]`
 - Invoked by: `dokku git-hook`, `dokku tar-build-locked`
-- Arguments: `$APP $IMAGE_SOURCE_TYPE $TMP_WORK_DIR`
+- Arguments: `$APP $IMAGE_SOURCE_TYPE $TMP_WORK_DIR $REV`
 - Example:
 
 ```shell
@@ -620,7 +620,7 @@ nginx -t
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-APP="$1"; IMAGE_SOURCE_TYPE="$2"; TMP_WORK_DIR="$3"
+APP="$1"; IMAGE_SOURCE_TYPE="$2"; TMP_WORK_DIR="$3"; REV="$4"
 
 echo "$APP" > "$TMP_WORK_DIR/dokku-is-awesome"
 ```

--- a/plugins/git/commands
+++ b/plugins/git/commands
@@ -21,10 +21,10 @@ git_build_app_repo() {
   find -name .git -prune -exec rm -rf {} \; > /dev/null
 
   if [[ -f Dockerfile ]] && [[ "$([[ -f .env ]] && grep -q BUILDPACK_URL .env; echo $?)" != "0" ]] && [[ ! -f ".buildpacks" ]]; then
-    plugn trigger pre-receive-app "$APP" "dockerfile" "$TMP_WORK_DIR"
+    plugn trigger pre-receive-app "$APP" "dockerfile" "$TMP_WORK_DIR" "$REV"
     dokku receive "$APP" "dockerfile" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
   else
-    plugn trigger pre-receive-app "$APP" "herokuish" "$TMP_WORK_DIR"
+    plugn trigger pre-receive-app "$APP" "herokuish" "$TMP_WORK_DIR" "$REV"
     dokku receive "$APP" "herokuish" "$TMP_WORK_DIR" | sed -u "s/^/"$'\e[1G'"/"
   fi
 }


### PR DESCRIPTION
I have a modified dokku-slack fork that inspects the incoming rev to extract the commit author and post it to slack in the `post-deploy` phase. This change facilities an easy way to get at the incoming revision. Seems like it would be useful for other applications as well.