### PR TITLE
set nullglob when looking for PORT files

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -167,9 +167,11 @@ case "$1" in
     fi
 
     if [[ "$(is_app_vhost_enabled $APP)" == "false" ]]; then
+      shopt -s nullglob
       for PORT_FILE in $DOKKU_ROOT/$APP/PORT.*; do
         echo "http://$(< "$DOKKU_ROOT/HOSTNAME"):$(< "$PORT_FILE") (container)"
       done
+      shopt -u nullglob
 
       DOKKU_NGINX_PORT=$(config_get $APP DOKKU_NGINX_PORT || true)
       DOKKU_NGINX_SSL_PORT=$(config_get $APP DOKKU_NGINX_SSL_PORT || true)


### PR DESCRIPTION
When deploying an app without a web proc **and** `$NO_VHOST` set, dokku will not generate a file that matches [this glob](https://github.com/progrium/dokku/blob/v0.4.4/plugins/00_dokku-standard/commands#L170) and thus will yield error output as indicated in #1678. 

It's also probably good code hygiene to guard nullglobs like this anyway. We do it almost everywhere else except for `backup-export/import` triggers but we know we are going to sort those out soon anyway.

NOTE: This is not a fatal error and does not cause dokku to fail deployment. 

closes #1678