### PR TITLE
Cause certs:remove to return non zero on error

### DIFF
--- a/plugins/certs/commands
+++ b/plugins/certs/commands
@@ -154,7 +154,7 @@ case "$1" in
       rm -rf $APP_SSL_PATH
       plugn trigger post-domains-update $APP
     else
-      dokku_log_info1 "An app-specific SSL endpoint is not defined"
+      dokku_log_fail "An app-specific SSL endpoint is not defined"
     fi
     ;;
 


### PR DESCRIPTION
This was caught when writing the certs.bats. This patch will return
non zero on error instead of zero which can casue false negatives
in testing.