### PR TITLE
Fix "App tls has not been deployed" error

### DIFF
--- a/plugins/00_dokku-standard/commands
+++ b/plugins/00_dokku-standard/commands
@@ -106,11 +106,11 @@ case "$1" in
     ;;
 
   ls)
-    dokku_apps=$(ls -d $DOKKU_ROOT/*/ 2>/dev/null) || (dokku_log_fail "You haven't deployed any applications yet")
+    installed_apps=$(dokku_apps)
 
     dokku_col_log_info1_quiet "App Name" "Container Type" "Container Id" "Status"
 
-    for dokku_app in $dokku_apps; do
+    for dokku_app in $installed_apps; do
       APP=$(basename $dokku_app)
       DOKKU_APP_CIDS=$(get_app_container_ids $APP)
       DOCKER_RUNNING_CONTAINERS=$(docker ps -q --no-trunc)

--- a/plugins/common/functions
+++ b/plugins/common/functions
@@ -9,6 +9,11 @@ has_tty() {
   fi
 }
 
+dokku_apps() {
+  local INSTALLED_APPS=$(find $DOKKU_ROOT -maxdepth 1 -mindepth 1 -type d ! -name 'tls' ! -name '.*' -printf "%f\n") || (dokku_log_fail "You haven't deployed any applications yet")
+  [[ $INSTALLED_APPS ]] && echo $INSTALLED_APPS
+}
+
 dokku_log_info1() {
   echo "-----> $*"
 }

--- a/plugins/ps/commands
+++ b/plugins/ps/commands
@@ -56,10 +56,8 @@ case "$1" in
 
   ps:rebuildall)
     shopt -s nullglob
-    for app in $DOKKU_ROOT/*; do
-      [[ ! -d $app ]] && continue
-      APP=$(basename $app)
-      is_deployed $APP && dokku ps:rebuild $APP
+    for app in $(dokku_apps); do
+      is_deployed $app && dokku ps:rebuild $app
     done
     shopt -u nullglob
     ;;
@@ -76,23 +74,19 @@ case "$1" in
 
   ps:restartall)
     shopt -s nullglob
-    for app in $DOKKU_ROOT/*; do
-      [[ ! -d $app ]] && continue
-      APP=$(basename $app)
-      dokku ps:restart $APP
+    for app in $(dokku_apps); do
+      dokku ps:restart $app
     done
     shopt -u nullglob
     ;;
 
   ps:restore)
     shopt -s nullglob
-    for app in $DOKKU_ROOT/*; do
-      [[ ! -d $app ]] && continue
-      APP=$(basename $app)
-      DOKKU_APP_RESTORE=$(dokku config:get $APP DOKKU_APP_RESTORE || true)
+    for app in $(dokku_apps); do
+      DOKKU_APP_RESTORE=$(dokku config:get $app DOKKU_APP_RESTORE || true)
       if [[ $DOKKU_APP_RESTORE != 0 ]]; then
-        echo "Restoring app $APP ..."
-        dokku ps:start $APP
+        echo "Restoring app $app ..."
+        dokku ps:start $app
       fi
     done
     shopt -u nullglob


### PR DESCRIPTION
This PR resolves #1571 

I created a function and specifically blacklisted `tls`. An alternative I explored was simply renaming the tls dir to .tls, but it was actually more lines of change since the tests have the path hardcoded.

Also caught this issue affecting `dokku ls` and resolved that too.