### PR TITLE
if the repo we are pushing has a CHECKS file...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ plugn:
 	tar xzf /tmp/plugn_latest.tgz -C /usr/local/bin
 
 docker: aufs
+	apt-get install -qq -y curl
 	egrep -i "^docker" /etc/group || groupadd docker
 	usermod -aG docker dokku
 ifndef CI


### PR DESCRIPTION
 the  check will fail because curl is not installed.

Making sure that curl is indeed installed on the VM.