### PR TITLE
Avoid using the PPA for ubuntu versions 15.10 and higher

### DIFF
--- a/plugins/nginx-vhosts/dependencies
+++ b/plugins/nginx-vhosts/dependencies
@@ -11,6 +11,12 @@ case "$DOKKU_DISTRO" in
     export DEBIAN_FRONTEND=noninteractive
     [[ -z "$CIRCLECI" ]] && apt-get install -qq -y software-properties-common python-software-properties
     [[ -n "$CIRCLECI" ]] && aptitude install -q -y software-properties-common python-software-properties
+
+    ubuntu_year=$(lsb_release -d | cut -d ' ' -f 2 | awk '{split($0,a,"."); print a[1]}')
+    ubuntu_month=$(lsb_release -d | cut -d ' ' -f 2 | awk '{split($0,a,"."); print a[2]}')
+    [[ "$ubuntu_year" -ge "16" ]] && exit 0
+    [[ "$ubuntu_year" -eq "15" ]] && [[ "$ubuntu_month" -eq "10" ]] && exit 0
+
     add-apt-repository -y ppa:nginx/stable
     apt-get update -qq > /dev/null
     apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" --force-yes -qq -y nginx dnsutils


### PR DESCRIPTION
As of 15.10, we are graced with a relatively recent version of nginx, and thus no longer need access to the ppa. Assuming this is the only such issue, this should also allow us to support Ubuntu 16.04 without any future changes.